### PR TITLE
feat(cat9): minimum-viable Category 9 scaffolding + 9b call-through success

### DIFF
--- a/sme/adapters/base.py
+++ b/sme/adapters/base.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 
@@ -46,6 +46,55 @@ class ContradictionPair:
     claim_b: str
     source_a: str  # entity/session id
     source_b: str
+
+
+@dataclass
+class ProbeResult:
+    """Outcome of probing a single HarnessDescriptor.
+
+    Minimum viable shape for Cat 9b (call-through success). A future
+    Cat 9a/9c implementation that involves a real model API will likely
+    extend this with ``reply_text``, ``model_invoked``, ``context_used``
+    etc. — treat this as a stable floor, not a frozen schema.
+    """
+
+    success: bool
+    latency_ms: float = 0.0
+    error: Optional[str] = None
+    # Free-form for diagnostics; not parsed by the scorecard.
+    output: Optional[str] = None
+
+
+@dataclass
+class HarnessDescriptor:
+    """Declaration of one way an external caller can reach this memory system.
+
+    Adapters return a list of these from ``get_harness_manifest()``. The
+    ``kind`` field follows the spec v8 § Cat 9 taxonomy. For the current
+    minimum-viable 9b, SME only needs ``probe_fn`` to do an end-to-end
+    dry call and report success/failure.
+
+    ``kind`` values:
+      - ``"tool_call"``       — a generic tool-call surface (OpenAI
+                                tool-calls, Anthropic tool-use, etc.)
+      - ``"mcp_resource"``    — an MCP server method the client calls
+                                over stdio/http
+      - ``"claude_code_hook"``— a Claude Code hook (Stop, PreCompact,
+                                UserPromptSubmit, SessionStart,
+                                PreToolUse, PostToolUse)
+      - ``"slash_command"``   — a harness-level slash command
+      - ``"custom_action"``   — arbitrary shape; the adapter owns the
+                                invocation semantics
+
+    Future sub-tests (9a/9c/9d/9e/9f/9g) will need the schema/URI/hook-
+    type info on top of ``probe_fn``; put them in ``properties`` for now.
+    """
+
+    name: str
+    kind: str
+    probe_fn: Callable[[], ProbeResult]
+    description: str = ""
+    properties: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -123,6 +172,21 @@ class SMEAdapter(ABC):
              'documentation': str}
         """
         return {"type": "inferred", "schema": [], "documentation": ""}
+
+    def get_harness_manifest(self) -> list[HarnessDescriptor]:
+        """Return the invocation surfaces this memory system exposes.
+
+        Used by Category 9 (Harness Integration). Each descriptor describes
+        one surface through which an external caller (a model, a hook, a
+        tool) can reach the memory system. Systems that don't expose any
+        harness surface — pure library APIs — return ``[]``.
+
+        The current minimum-viable consumer (Cat 9b call-through success)
+        only invokes ``probe_fn`` on each descriptor. Future sub-tests
+        will need the ``kind`` + ``properties`` metadata to run model
+        calls and compose with Cat 7.
+        """
+        return []
 
     # --- Lifecycle -----------------------------------------------------
 

--- a/sme/adapters/mempalace.py
+++ b/sme/adapters/mempalace.py
@@ -46,9 +46,16 @@ import os
 import sqlite3
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional
 
-from sme.adapters.base import Edge, Entity, QueryResult, SMEAdapter
+from sme.adapters.base import (
+    Edge,
+    Entity,
+    HarnessDescriptor,
+    ProbeResult,
+    QueryResult,
+    SMEAdapter,
+)
 
 log = logging.getLogger(__name__)
 
@@ -622,6 +629,126 @@ class MemPalaceAdapter(SMEAdapter):
                 "live in a separate SQLite store."
             ),
         }
+
+    # --- Category 9 harness manifest ----------------------------------
+
+    def get_harness_manifest(self) -> list[HarnessDescriptor]:
+        """Declare MemPalace's MCP-style invocation surfaces for Cat 9.
+
+        The adapter itself talks to ChromaDB + SQLite directly — it does
+        not spawn the actual mempalace MCP server process. Each probe
+        here exercises the same code path that the corresponding MCP
+        tool does on the live server, so a probe failure here predicts
+        an MCP-side failure on that tool. A probe success does NOT
+        guarantee the MCP stdio/JSON-RPC layer is wired correctly —
+        that's a separate concern for a future 9f (per-harness
+        portability) implementation that actually spawns the server.
+        """
+        return [
+            HarnessDescriptor(
+                name="mempalace_search",
+                kind="mcp_resource",
+                probe_fn=self._probe_search,
+                description="MCP tool: semantic search over drawers",
+                properties={
+                    "tool_name": "mempalace_search",
+                    "underlying_call": "query()",
+                },
+            ),
+            HarnessDescriptor(
+                name="mempalace_graph_stats",
+                kind="mcp_resource",
+                probe_fn=self._probe_graph_snapshot,
+                description="MCP tool: wing/room/tunnel graph summary",
+                properties={
+                    "tool_name": "mempalace_graph_stats",
+                    "underlying_call": "get_graph_snapshot()",
+                },
+            ),
+            HarnessDescriptor(
+                name="mempalace_kg_query",
+                kind="mcp_resource",
+                probe_fn=self._probe_kg_read,
+                description="MCP tool: knowledge-graph triple lookup",
+                properties={
+                    "tool_name": "mempalace_kg_query",
+                    "underlying_call": "_read_kg()",
+                    "optional": True,  # skipped gracefully if KG absent
+                },
+            ),
+        ]
+
+    def _probe_search(self) -> ProbeResult:
+        """Call query() with a neutral probe string, check shape."""
+        import time
+
+        start = time.perf_counter()
+        try:
+            result = self.query("probe query test")
+        except Exception as exc:  # noqa: BLE001 — adapter probe, all errors captured
+            return ProbeResult(
+                success=False,
+                latency_ms=(time.perf_counter() - start) * 1000,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        latency = (time.perf_counter() - start) * 1000
+        if result.error:
+            return ProbeResult(success=False, latency_ms=latency, error=result.error)
+        # "Success" means the machinery returned a QueryResult with
+        # context_string populated. Zero hits is still a successful
+        # call-through — that's a retrieval-quality question (Cat 1),
+        # not a harness-integration question (Cat 9b).
+        return ProbeResult(
+            success=True,
+            latency_ms=latency,
+            output=f"context_string length={len(result.context_string or '')}",
+        )
+
+    def _probe_graph_snapshot(self) -> ProbeResult:
+        import time
+
+        start = time.perf_counter()
+        try:
+            entities, edges = self.get_graph_snapshot()
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                success=False,
+                latency_ms=(time.perf_counter() - start) * 1000,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        return ProbeResult(
+            success=True,
+            latency_ms=(time.perf_counter() - start) * 1000,
+            output=f"entities={len(entities)} edges={len(edges)}",
+        )
+
+    def _probe_kg_read(self) -> ProbeResult:
+        """Probe the KG read path. Graceful no-op if KG file absent."""
+        import time
+
+        start = time.perf_counter()
+        if not (self.kg_path and os.path.isfile(self.kg_path)):
+            # No KG file — the corresponding MCP tool would return an
+            # empty result, not crash. Report success so we don't
+            # penalize palaces without a KG.
+            return ProbeResult(
+                success=True,
+                latency_ms=(time.perf_counter() - start) * 1000,
+                output=f"kg file not present at {self.kg_path!r}; probe skipped",
+            )
+        try:
+            entities, edges = self._read_kg()
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                success=False,
+                latency_ms=(time.perf_counter() - start) * 1000,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        return ProbeResult(
+            success=True,
+            latency_ms=(time.perf_counter() - start) * 1000,
+            output=f"kg_entities={len(entities)} kg_triples={len(edges)}",
+        )
 
     # --- Lifecycle ----------------------------------------------------
 

--- a/sme/categories/harness_integration.py
+++ b/sme/categories/harness_integration.py
@@ -1,0 +1,259 @@
+"""Category 9: Harness Integration — The Handshake.
+
+Tests whether the memory system is actually reachable through its
+declared invocation surfaces (MCP servers, Claude Code hooks, tool
+calls, slash commands, custom actions). Every other SME category
+measures offline retrieval — this category measures the layer between
+retrieval and a running model.
+
+Current scope (minimum viable):
+
+  9b  Call-through success
+      For each ``HarnessDescriptor`` returned by the adapter, invoke
+      ``probe_fn`` once and report whether the call completed. A low
+      9b means the integration is broken (bad schema, timeout, wrong
+      parameters, tool not registered, MCP server unreachable). A high
+      9b means the surface is live — it says nothing about whether the
+      model will actually invoke it, which is what 9a measures and
+      needs a real model runtime.
+
+Planned (not implemented here; see spec v8 § Category 9):
+
+  9a  Invocation rate       — needs real model API
+  9c  Result usage          — needs real model API + Cat 1 matcher
+  9d  Negative-control rate — needs real model API + held-out set
+  9e  Per-model sensitivity — needs multi-model API access
+  9f  Per-harness portability — needs per-harness runners
+  9g  Hook-driven access    — needs per-harness shims (Claude Code,
+                               Cursor, LangGraph, etc.)
+
+9b being implemented first is deliberate: per the spec, it's the one
+sub-test that "can be measured against a mock model that always invokes
+the tool." No API keys, no cost, no per-harness shim. A clean floor.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+
+from sme.adapters.base import HarnessDescriptor, ProbeResult, SMEAdapter
+
+log = logging.getLogger(__name__)
+
+
+# --- Bands for the Reading section ------------------------------------
+
+_CALL_THROUGH_HEALTHY = 1.00   # all surfaces callable
+_CALL_THROUGH_WARN = 0.80      # 80-99% — partial integration
+
+
+def _band(value: float, healthy: float, warn: float) -> str:
+    if value >= healthy:
+        return "healthy"
+    if value >= warn:
+        return "warn"
+    return "concerning"
+
+
+# --- Result types -----------------------------------------------------
+
+
+@dataclass
+class ProbeReading:
+    """One descriptor's probe outcome with SME-side wrapping."""
+
+    descriptor: HarnessDescriptor
+    result: ProbeResult
+
+
+@dataclass
+class Cat9bResult:
+    """Category 9b — call-through success — scorecard."""
+
+    total_probes: int
+    successful_probes: int
+    failed_probes: int
+    # Probes grouped by HarnessDescriptor.kind for per-surface breakdown.
+    by_kind: dict[str, dict[str, int]] = field(default_factory=dict)
+    readings: list[ProbeReading] = field(default_factory=list)
+    # Present when the adapter declares no manifest — distinct from zero
+    # probes succeeding (which is a real failure).
+    empty_manifest: bool = False
+
+    @property
+    def call_through_rate(self) -> float:
+        if self.total_probes == 0:
+            return 0.0
+        return self.successful_probes / self.total_probes
+
+    @property
+    def band(self) -> str:
+        if self.empty_manifest:
+            return "n/a"
+        return _band(self.call_through_rate, _CALL_THROUGH_HEALTHY, _CALL_THROUGH_WARN)
+
+
+# --- Sub-test: 9b call-through success --------------------------------
+
+
+def run_cat9b(adapter: SMEAdapter, *, timeout_per_probe_s: float = 10.0) -> Cat9bResult:
+    """Execute Category 9b against an adapter's declared harness manifest.
+
+    Invokes each ``HarnessDescriptor.probe_fn`` exactly once and tallies
+    successes. A probe that raises an exception counts as a failure with
+    the exception message captured in ``ProbeResult.error``. A probe
+    that exceeds ``timeout_per_probe_s`` is not automatically aborted —
+    the probe_fn owns its own timeout semantics — but the elapsed
+    wall-clock is recorded in ``ProbeResult.latency_ms``.
+
+    Consumers of this function (the CLI, a CI harness, a test) should
+    treat an empty manifest as "the adapter doesn't declare a harness
+    surface" — a reporting outcome, not a pass/fail.
+    """
+    manifest = adapter.get_harness_manifest()
+
+    if not manifest:
+        return Cat9bResult(
+            total_probes=0,
+            successful_probes=0,
+            failed_probes=0,
+            empty_manifest=True,
+        )
+
+    readings: list[ProbeReading] = []
+    by_kind: dict[str, dict[str, int]] = {}
+    successful = 0
+    failed = 0
+
+    for descriptor in manifest:
+        start = time.perf_counter()
+        try:
+            result = descriptor.probe_fn()
+            if not isinstance(result, ProbeResult):
+                # Tolerate the common mistake of returning a bool.
+                result = ProbeResult(
+                    success=bool(result),
+                    latency_ms=(time.perf_counter() - start) * 1000,
+                    error=None if result else "probe_fn returned non-ProbeResult falsy value",
+                )
+            # Fill latency if the probe forgot to.
+            if result.latency_ms == 0.0:
+                result.latency_ms = (time.perf_counter() - start) * 1000
+        except Exception as exc:  # noqa: BLE001 — intentional; probe_fn is user code
+            latency = (time.perf_counter() - start) * 1000
+            log.debug("probe %r raised %s", descriptor.name, exc)
+            result = ProbeResult(
+                success=False,
+                latency_ms=latency,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        readings.append(ProbeReading(descriptor=descriptor, result=result))
+
+        kind_bucket = by_kind.setdefault(descriptor.kind, {"success": 0, "fail": 0})
+        if result.success:
+            successful += 1
+            kind_bucket["success"] += 1
+        else:
+            failed += 1
+            kind_bucket["fail"] += 1
+
+    return Cat9bResult(
+        total_probes=len(manifest),
+        successful_probes=successful,
+        failed_probes=failed,
+        by_kind=by_kind,
+        readings=readings,
+        empty_manifest=False,
+    )
+
+
+# --- Formatting helpers (used by the CLI) -----------------------------
+
+
+def format_cat9b_report(result: Cat9bResult, *, source_label: str = "") -> str:
+    """Return a human-readable scorecard for Category 9b.
+
+    Follows the same banded-reading shape as ``cat4`` / ``cat5`` so the
+    CLI output stays consistent. Probe-level detail is included so a
+    failing call-through rate is actionable.
+    """
+    lines: list[str] = []
+
+    header = "Category 9b — Harness Integration (Call-Through Success)"
+    if source_label:
+        header = f"{header} — {source_label}"
+    lines.append(header)
+    lines.append("=" * len(header))
+    lines.append("")
+
+    if result.empty_manifest:
+        lines.append(
+            "  Adapter declared no harness manifest — pure library usage only. "
+            "Cat 9b does not apply."
+        )
+        lines.append("")
+        lines.append(
+            "  If this memory system is reachable via MCP, hooks, tool calls, or "
+            "slash commands, implement ``get_harness_manifest()`` so SME can probe "
+            "each surface."
+        )
+        return "\n".join(lines) + "\n"
+
+    rate_pct = result.call_through_rate * 100
+    lines.append(
+        f"  Probes: {result.total_probes} total — "
+        f"{result.successful_probes} succeeded, "
+        f"{result.failed_probes} failed "
+        f"({rate_pct:.1f}% call-through, band: {result.band})"
+    )
+    lines.append("")
+
+    if result.by_kind:
+        lines.append("  By surface kind:")
+        for kind, counts in sorted(result.by_kind.items()):
+            total = counts["success"] + counts["fail"]
+            success = counts["success"]
+            pct = (success / total * 100) if total else 0.0
+            lines.append(f"    {kind:22} {success}/{total} ({pct:.0f}%)")
+        lines.append("")
+
+    if result.failed_probes:
+        lines.append("  Failed probes:")
+        for reading in result.readings:
+            if reading.result.success:
+                continue
+            error = reading.result.error or "(no error captured)"
+            lines.append(
+                f"    - {reading.descriptor.kind}/{reading.descriptor.name}: {error}"
+            )
+        lines.append("")
+
+    lines.append("  Reading:")
+    if result.band == "healthy":
+        lines.append(
+            "    All declared surfaces answered. The memory system is live at every "
+            "harness point it claims to support."
+        )
+    elif result.band == "warn":
+        lines.append(
+            "    Some surfaces are unreachable. Likely integration regressions rather "
+            "than retrieval problems — inspect the failed probes above."
+        )
+    else:
+        lines.append(
+            "    Most surfaces failed to respond. The memory system is effectively "
+            "unavailable to callers using the declared harness contract. Cat 9a "
+            "(invocation rate) readings downstream of this will be artificially low."
+        )
+    lines.append("")
+
+    lines.append(
+        "  Note: 9b measures whether a mock-invoker can reach each surface. It does "
+        "NOT measure whether a real model would actually invoke the tool (9a), use "
+        "the result (9c), or skip when unnecessary (9d). Those sub-tests require a "
+        "real model runtime and are tracked separately."
+    )
+    return "\n".join(lines) + "\n"

--- a/sme/cli.py
+++ b/sme/cli.py
@@ -80,7 +80,7 @@ def _print_report(
     print(" Structural Memory Evaluation — structural analysis")
     print("=" * 70)
 
-    print(f"\nGraph size")
+    print("\nGraph size")
     print(f"  nodes:                {_fmt_int(health['nodes'])}")
     print(f"  edges:                {_fmt_int(health['edges'])}")
     print(f"  components:           {_fmt_int(health['components'])}")
@@ -92,11 +92,11 @@ def _print_report(
     print(f"  avg degree:           {health['avg_degree']:.2f}")
     print(f"  max degree:           {_fmt_int(health['max_degree'])}")
 
-    print(f"\nEntity type distribution")
+    print("\nEntity type distribution")
     for et, c in list(health["entity_type_distribution"].items())[:15]:
         print(f"  {et:35s} {c:>8,}")
 
-    print(f"\nEdge type distribution")
+    print("\nEdge type distribution")
     total_edges = sum(health["edge_type_distribution"].values()) or 1
     for et, c in health["edge_type_distribution"].items():
         pct = 100 * c / total_edges
@@ -107,7 +107,7 @@ def _print_report(
         "low bits indicate monoculture)"
     )
 
-    print(f"\nCommunity structure (Louvain)")
+    print("\nCommunity structure (Louvain)")
     print(f"  communities:          {_fmt_int(community.count)}")
     print(f"  modularity:           {community.modularity:.3f}")
     print(
@@ -116,14 +116,14 @@ def _print_report(
     )
     print(f"  top sizes:            {community.sizes[:10]}")
 
-    print(f"\nPer-edge-type component count  (Cat 4c monoculture signal)")
+    print("\nPer-edge-type component count  (Cat 4c monoculture signal)")
     for et, n_comp in sorted(
         edge_type_components.items(), key=lambda kv: -kv[1]
     )[:15]:
         print(f"  {et:35s} {n_comp:>8,}  components")
 
     if betti is not None:
-        print(f"\nPersistent homology  (Cat 5 gap detection)")
+        print("\nPersistent homology  (Cat 5 gap detection)")
         print(
             f"  component size:       {_fmt_int(betti.component_size)} nodes"
             f"  (largest connected component)"
@@ -141,7 +141,7 @@ def _print_report(
             )
             if betti.h1_bars:
                 print(f"  max H1 persistence:   {betti.max_h1_persistence:.2f} hops")
-                print(f"  top H1 bars (birth, death, persistence):")
+                print("  top H1 bars (birth, death, persistence):")
                 for b, d, p in betti.h1_bars[:10]:
                     print(
                         f"    birth={b:5.2f}  death={d:5.2f}  persistence={p:5.2f}"
@@ -181,7 +181,7 @@ def _print_report(
             for line in textwrap.wrap(doc, width=66):
                 print(f"    {line}")
 
-    print(f"\nTiming")
+    print("\nTiming")
     for step, t in elapsed.items():
         print(f"  {step:20s} {t:>7.2f}s")
     print()
@@ -278,7 +278,6 @@ def cmd_analyze(args: argparse.Namespace) -> int:
 
 def cmd_cat8(args: argparse.Namespace) -> int:
     """Run Category 8 ontology coherence against a system."""
-    import textwrap
 
     from sme.categories.ontology_coherence import (
         ImpliedOntology,
@@ -339,7 +338,7 @@ def cmd_cat8(args: argparse.Namespace) -> int:
     print(f"  vocabulary claims:      {len(implied.vocabulary_claims)}")
     print(f"  retrieval claims:       {len(implied.retrieval_claims)}")
 
-    print(f"\n8a Type coverage")
+    print("\n8a Type coverage")
     print(f"   declared:   {len(report.types_declared)}")
     print(f"   found:      {len(report.types_found)}  ({', '.join(report.types_found) or '—'})")
     print(f"   missing:    {len(report.types_missing)}  ({', '.join(report.types_missing) or '—'})")
@@ -349,7 +348,7 @@ def cmd_cat8(args: argparse.Namespace) -> int:
             print(f"     - {t}")
     print(f"   coverage:   {report.type_coverage:.1%}")
 
-    print(f"\n8b Edge vocabulary")
+    print("\n8b Edge vocabulary")
     print(f"   declared:   {len(report.edges_declared)}")
     print(f"   found:      {len(report.edges_found)}  ({', '.join(report.edges_found) or '—'})")
     print(f"   missing:    {len(report.edges_missing)}  ({', '.join(report.edges_missing) or '—'})")
@@ -357,7 +356,7 @@ def cmd_cat8(args: argparse.Namespace) -> int:
         print(f"   undeclared: {len(report.edges_undeclared)}  ({', '.join(report.edges_undeclared[:8])}{'...' if len(report.edges_undeclared) > 8 else ''})")
     print(f"   coverage:   {report.edge_vocabulary_coverage:.1%}")
 
-    print(f"\n8c Schema-data alignment")
+    print("\n8c Schema-data alignment")
     if report.entity_type_concentration:
         c = report.entity_type_concentration
         print(
@@ -368,13 +367,13 @@ def cmd_cat8(args: argparse.Namespace) -> int:
     if report.concentration_warning:
         print(f"   ⚠ {report.concentration_warning}")
 
-    print(f"\n8d Ontology drift")
+    print("\n8d Ontology drift")
     print(f"   drift score:      {report.drift_score:.1%}")
     print(f"   declared union:   {len(report.declared_union)}")
     print(f"   effective union:  {len(report.effective_union)}")
     if report.hall_usage:
         hu = report.hall_usage
-        print(f"\n   Hall usage (MemPalace-specific):")
+        print("\n   Hall usage (MemPalace-specific):")
         print(f"     total drawers:         {hu['total_drawers']}")
         print(
             f"     drawers with hall set: {hu['populated_count']}  "
@@ -382,13 +381,13 @@ def cmd_cat8(args: argparse.Namespace) -> int:
         )
         print(f"     declared vocabulary:   {', '.join(hu['declared_vocabulary'])}")
         if hu["distribution"]:
-            print(f"     actual distribution:")
+            print("     actual distribution:")
             for hv, c in list(hu["distribution"].items())[:10]:
                 print(f"       {hv:20s} {c}")
         else:
-            print(f"     actual distribution:   (empty — no drawers have hall set)")
+            print("     actual distribution:   (empty — no drawers have hall set)")
 
-    print(f"\n8e Claim verification")
+    print("\n8e Claim verification")
     print(f"   tested:      {report.claims_tested}")
     print(f"   passed:      {report.claims_passed}")
     print(f"   untestable:  {report.claims_untestable}")
@@ -416,7 +415,7 @@ def cmd_cat8(args: argparse.Namespace) -> int:
             print(f"        data:  {short_metrics}")
         print()
 
-    print(f"Introspection")
+    print("Introspection")
     print(f"   available checks: {len(report.introspection_available)}")
     print(f"   score:            {report.introspection_score:.1%}")
     print(
@@ -718,6 +717,71 @@ def cmd_cat2c(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_cat9(args: argparse.Namespace) -> int:
+    """Run Category 9 (harness integration) against a system.
+
+    Current scope: sub-test 9b (call-through success) only. Other
+    sub-tests (9a, 9c–9g) are spec'd in ``docs/sme_spec_v8.md §
+    Category 9`` and will require a real model runtime / per-harness
+    shims — implementations are tracked separately.
+    """
+    subtest = getattr(args, "subtest", "9b") or "9b"
+
+    if subtest != "9b":
+        print(
+            f"Sub-test {subtest} is spec'd but not implemented. "
+            "Only 9b (call-through success) is currently supported. "
+            "See docs/sme_spec_v8.md § Category 9 for the full plan."
+        )
+        return 2
+
+    from sme.categories.harness_integration import format_cat9b_report, run_cat9b
+
+    adapter = _load_adapter_from_args(args)
+    result = run_cat9b(adapter)
+
+    print()
+    print("=" * 70)
+    print(f" {args.adapter} ({_source_label(args)})")
+    print("=" * 70)
+    print(format_cat9b_report(result, source_label=_source_label(args)))
+
+    if args.json:
+        out = {
+            "adapter": args.adapter,
+            "source": _source_label(args),
+            "subtest": subtest,
+            "empty_manifest": result.empty_manifest,
+            "total_probes": result.total_probes,
+            "successful_probes": result.successful_probes,
+            "failed_probes": result.failed_probes,
+            "call_through_rate": result.call_through_rate,
+            "band": result.band,
+            "by_kind": result.by_kind,
+            "probes": [
+                {
+                    "name": r.descriptor.name,
+                    "kind": r.descriptor.kind,
+                    "description": r.descriptor.description,
+                    "success": r.result.success,
+                    "latency_ms": r.result.latency_ms,
+                    "error": r.result.error,
+                    "output": r.result.output,
+                }
+                for r in result.readings
+            ],
+        }
+        Path(args.json).write_text(json.dumps(out, indent=2, default=str))
+        print(f"\nJSON report written to {args.json}")
+
+    adapter.close()
+    # Exit code: 0 on healthy call-through, 1 on any failed probe,
+    # 2 for empty-manifest (reporting outcome, not pass/fail).
+    if result.empty_manifest:
+        return 2
+    return 0 if result.failed_probes == 0 else 1
+
+
 def cmd_retrieve(args: argparse.Namespace) -> int:
     """Run a question set through an adapter's query() and score it."""
     import yaml
@@ -865,7 +929,7 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
     print(f"  partial hit:   {sum(1 for pq in per_question if pq['hit'])}/{total_n}")
     print(f"  total tokens:  {total_tokens:,}")
     print(
-        f"  tokens / correct answer: "
+        "  tokens / correct answer: "
         + (f"{tokens_per_correct:.0f}" if correct_count else "inf (no full-recall questions)")
     )
 
@@ -1280,6 +1344,27 @@ def main(argv: list[str] | None = None) -> int:
     )
     c2c.add_argument("--json", metavar="PATH", help="write full report as JSON")
     c2c.set_defaults(func=cmd_cat2c)
+
+    # --- cat9 subcommand ---------------------------------------------
+    c9 = sub.add_parser(
+        "cat9",
+        help="Run Category 9 (harness integration — The Handshake). "
+        "Current scope: sub-test 9b (call-through success). Probes each "
+        "declared harness surface to verify external callers can actually "
+        "reach the memory system. Other sub-tests (9a, 9c–9g) are spec'd "
+        "but need a real model runtime — see docs/sme_spec_v8.md.",
+    )
+    c9.add_argument("--adapter", required=True)
+    _add_db_or_api_args(c9)
+    c9.add_argument(
+        "--subtest",
+        default="9b",
+        choices=["9b"],
+        help="Which Cat 9 sub-test to run (default: 9b call-through success). "
+        "9a, 9c–9g are spec'd but not implemented.",
+    )
+    c9.add_argument("--json", metavar="PATH", help="write full report as JSON")
+    c9.set_defaults(func=cmd_cat9)
 
     args = parser.parse_args(argv)
     logging.basicConfig(

--- a/tests/test_harness_integration.py
+++ b/tests/test_harness_integration.py
@@ -1,0 +1,195 @@
+"""Tests for Category 9: Harness Integration — The Handshake.
+
+Covers the 9b sub-test (call-through success) only — the minimum-viable
+surface currently implemented. Other sub-tests (9a, 9c–9g) are spec'd
+but not implemented and therefore have no tests here.
+"""
+
+from __future__ import annotations
+
+from sme.adapters.base import HarnessDescriptor, ProbeResult, SMEAdapter
+from sme.categories.harness_integration import (
+    format_cat9b_report,
+    run_cat9b,
+)
+
+
+class _StubAdapter(SMEAdapter):
+    """Minimal adapter that lets a test pre-declare a harness manifest.
+
+    Only overrides the three abstract methods + get_harness_manifest().
+    """
+
+    def __init__(self, manifest: list[HarnessDescriptor]) -> None:
+        self._manifest = manifest
+
+    def ingest_corpus(self, corpus):
+        return {"entities_created": 0, "edges_created": 0, "errors": [], "warnings": []}
+
+    def query(self, question):
+        from sme.adapters.base import QueryResult
+
+        return QueryResult(answer="")
+
+    def get_graph_snapshot(self):
+        return [], []
+
+    def get_harness_manifest(self):
+        return self._manifest
+
+
+# --- 9b: empty manifest ------------------------------------------------
+
+
+def test_cat9b_empty_manifest_reports_not_applicable():
+    adapter = _StubAdapter(manifest=[])
+    result = run_cat9b(adapter)
+    assert result.empty_manifest is True
+    assert result.total_probes == 0
+    assert result.band == "n/a"
+    report = format_cat9b_report(result)
+    assert "declared no harness manifest" in report
+
+
+# --- 9b: all probes succeed --------------------------------------------
+
+
+def test_cat9b_all_probes_succeed_is_healthy():
+    descriptors = [
+        HarnessDescriptor(
+            name=f"probe_{i}",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=True, latency_ms=1.0),
+        )
+        for i in range(3)
+    ]
+    adapter = _StubAdapter(manifest=descriptors)
+    result = run_cat9b(adapter)
+    assert result.total_probes == 3
+    assert result.successful_probes == 3
+    assert result.failed_probes == 0
+    assert result.call_through_rate == 1.0
+    assert result.band == "healthy"
+
+
+# --- 9b: probe raises an exception -------------------------------------
+
+
+def test_cat9b_raising_probe_counts_as_failure():
+    def boom() -> ProbeResult:
+        raise RuntimeError("integration broken")
+
+    adapter = _StubAdapter(
+        manifest=[
+            HarnessDescriptor(name="boom", kind="tool_call", probe_fn=boom),
+        ]
+    )
+    result = run_cat9b(adapter)
+    assert result.failed_probes == 1
+    assert result.successful_probes == 0
+    assert result.readings[0].result.success is False
+    assert "RuntimeError" in (result.readings[0].result.error or "")
+
+
+# --- 9b: mixed outcomes give correct banding ---------------------------
+
+
+def test_cat9b_mixed_outcomes_produce_warn_band():
+    # 4 probes total, 3 succeed, 1 fails → 75% → concerning (< 80% warn floor)
+    descriptors = [
+        HarnessDescriptor(
+            name=f"ok_{i}",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=True, latency_ms=1.0),
+        )
+        for i in range(3)
+    ]
+    descriptors.append(
+        HarnessDescriptor(
+            name="bad",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=False, error="timeout"),
+        )
+    )
+    adapter = _StubAdapter(manifest=descriptors)
+    result = run_cat9b(adapter)
+    assert result.total_probes == 4
+    assert result.successful_probes == 3
+    assert result.failed_probes == 1
+    assert abs(result.call_through_rate - 0.75) < 1e-9
+    assert result.band == "concerning"  # 75% < 80% warn threshold
+
+
+def test_cat9b_warn_band_at_exactly_80_percent():
+    # 5 probes, 4 succeed → 80% → warn band
+    descriptors = [
+        HarnessDescriptor(
+            name=f"ok_{i}",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=True, latency_ms=1.0),
+        )
+        for i in range(4)
+    ]
+    descriptors.append(
+        HarnessDescriptor(
+            name="bad",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=False, error="timeout"),
+        )
+    )
+    adapter = _StubAdapter(manifest=descriptors)
+    result = run_cat9b(adapter)
+    assert result.band == "warn"
+
+
+# --- 9b: by-kind breakdown ---------------------------------------------
+
+
+def test_cat9b_by_kind_counts_are_accurate():
+    descriptors = [
+        HarnessDescriptor(
+            name="mcp_ok",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=True),
+        ),
+        HarnessDescriptor(
+            name="mcp_bad",
+            kind="mcp_resource",
+            probe_fn=lambda: ProbeResult(success=False, error="x"),
+        ),
+        HarnessDescriptor(
+            name="hook_ok",
+            kind="claude_code_hook",
+            probe_fn=lambda: ProbeResult(success=True),
+        ),
+    ]
+    adapter = _StubAdapter(manifest=descriptors)
+    result = run_cat9b(adapter)
+    assert result.by_kind["mcp_resource"] == {"success": 1, "fail": 1}
+    assert result.by_kind["claude_code_hook"] == {"success": 1, "fail": 0}
+
+
+# --- 9b: bool-returning probe is tolerated -----------------------------
+
+
+def test_cat9b_probe_returning_bool_is_coerced():
+    """Defensive: users may reasonably write `return True` instead of
+    `return ProbeResult(success=True)`. The runner coerces and continues.
+    """
+    adapter = _StubAdapter(
+        manifest=[
+            HarnessDescriptor(
+                name="naive_true",
+                kind="tool_call",
+                probe_fn=lambda: True,  # type: ignore[return-value]
+            ),
+            HarnessDescriptor(
+                name="naive_false",
+                kind="tool_call",
+                probe_fn=lambda: False,  # type: ignore[return-value]
+            ),
+        ]
+    )
+    result = run_cat9b(adapter)
+    assert result.successful_probes == 1
+    assert result.failed_probes == 1


### PR DESCRIPTION
## Summary

Adds Category 9 (Harness Integration — The Handshake) in the minimum-viable scope called out in your spec: sub-test **9b (call-through success)** with a mock-invoker, no real-model API required. Other sub-tests (9a, 9c–9g) are cleanly rejected by the CLI with a "spec'd but not implemented" message, so they can be filed incrementally.

Your spec calls Cat 9 "the single most important planned addition to the framework." This PR doesn't ship the whole category — it ships the one sub-test the spec itself calls out as implementable without an API key ("9b can be measured against a mock model that always invokes the tool"), plus the scaffolding (`HarnessDescriptor`, `ProbeResult`, `get_harness_manifest()`, CLI subcommand, banded scorecard) that lets each remaining sub-test land as its own focused PR.

## What's in this PR

| File | Change |
|---|---|
| `sme/adapters/base.py` | New `ProbeResult` + `HarnessDescriptor` dataclasses; new optional `SMEAdapter.get_harness_manifest()` returning `[]` by default |
| `sme/categories/harness_integration.py` | `run_cat9b()`, `format_cat9b_report()`, `Cat9bResult` with banded readings (healthy 100% / warn ≥80% / concerning <80%) matching cat4/cat5 shape |
| `sme/adapters/mempalace.py` | First `get_harness_manifest()` implementation — three probes: `mempalace_search`, `mempalace_graph_stats`, `mempalace_kg_query` (gracefully skipped when KG file absent) |
| `sme/cli.py` | `sme-eval cat9 --adapter X --db Y --subtest 9b` subcommand; `--json` output; exit codes 0/1/2 for healthy/failed/empty-manifest |
| `tests/test_harness_integration.py` | 7 tests: empty manifest, all-success, raising probe, mixed outcomes at 75% + 80% thresholds, by-kind breakdown, bool-returning probe tolerance |

All tests pass (7 new, 33 pre-existing, 1 pre-existing skipped). `ruff check` on the new files is clean.

## What's intentionally NOT in this PR

Per your spec's Cat 9 § Requirements, sub-tests 9a/9c/9d/9e/9f/9g need a real model runtime or per-harness shims. The CLI rejects them with a clear message pointing at the spec rather than silently running the wrong thing. Each can be a follow-up PR.

The `HarnessDescriptor.kind` field uses the spec's taxonomy (`tool_call`, `mcp_resource`, `claude_code_hook`, `slash_command`, `custom_action`) so future per-harness runners can dispatch on it. `properties` is a dict bag so schema / URI / hook-type info can be attached per-adapter without breaking the base interface.

## Real-world signal from the MemPalace adapter

Ran `sme-eval cat9 --adapter mempalace --db ~/.mempalace/palace` against a production palace (165K drawers across ~28 wings):

```
Probes: 3 total — 2 succeeded, 1 failed (66.7% call-through, band: concerning)

By surface kind:
    mcp_resource           2/3 (67%)

Failed probes:
    - mcp_resource/mempalace_graph_stats: AttributeError: 'NoneType' object has no attribute 'get'
```

The `mempalace_graph_stats` probe surfaced a real `AttributeError` in the adapter's `get_graph_snapshot` path on a large production palace — exactly the class of integration bug Cat 9b is designed to catch. Reporting this upstream in MemPalace separately; the bug is in the adapter, not the framework.

## Design questions I deliberately chose for you to overrule

1. **Thresholds.** Healthy = 100% / warn ≥ 80% / concerning < 80%. I picked "healthy means nothing broken" because 9b is a binary integration test, not a quality metric. Happy to relax to 95% if you'd rather treat one flaky tool as not-blocking.
2. **Bool coercion.** Probes that return `True`/`False` instead of a `ProbeResult` get coerced with a warning in the error field. Defensive; open to deleting if you'd rather be strict.
3. **Empty-manifest exit code.** Currently 2 (distinct from pass/fail). Rationale: "library-only systems have no harness to test" is a reporting outcome, not a bug. Could collapse to 0 if you prefer.
4. **Probe timeout.** `timeout_per_probe_s` parameter exists in the signature but isn't enforced — probe_fns own their own timeouts. Could wire `concurrent.futures` in a follow-up if you want the framework to cap runaway probes.

## Test plan

- [x] `pytest tests/test_harness_integration.py -v` → 7 passed
- [x] `pytest tests/` full suite → 33 passed, 1 skipped (pre-existing)
- [x] `ruff check` on all new/modified files → clean
- [x] Live run: `sme-eval cat9 --adapter mempalace --db ~/.mempalace/palace` → surfaces a real bug

## Context

I'm JP (@jphein), maintainer of [jphein/mempalace](https://github.com/jphein/mempalace). Running a ~165K-drawer production palace since 2026-04-09. Opened [#1 on palace-daemon](https://github.com/rboarescu/palace-daemon/issues/1) and [#1 on cdd-mempalace](https://github.com/fuzzymoomoo/cdd-mempalace/issues/1) this morning for similar collaboration-first framing. Happy to iterate on the interface design here — your spec is doing real work and I want this PR to fit it, not impose a shape you'd have to rework later.