### PR TITLE
feat(eval): FamiliarAdapter + jp-realm-v0.1 corpus + first live readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,60 +84,64 @@ the documentation and code.
 This is a fork; planned fork-specific work below. Upstream is
 [M0nkeyFl0wer/multipass-structural-memory-eval](https://github.com/M0nkeyFl0wer/multipass-structural-memory-eval) — bug fixes and category contributions still target upstream.
 
-### Planned: `mempalace-daemon` adapter
+### Shipped: `mempalace-daemon` adapter
 
-The shipped `sme/adapters/mempalace.py` opens ChromaDB directly via
-`chromadb.PersistentClient`. That works for upstream MemPalace
-single-process installs but **violates the daemon-strict invariant**
-of the [palace-daemon](https://github.com/jphein/palace-daemon) /
-[jphein/mempalace](https://github.com/jphein/mempalace) architecture
-where the daemon is the only process allowed to open the palace
-SQLite. Two `PersistentClient` instances against the same palace =
-the multi-writer corruption scenario the daemon was built to
-prevent. Even for SME's read-only adapter calls, holding ChromaDB
-file handles parallel to the daemon's writers is the wrong shape.
+`sme/adapters/mempalace_daemon.py` talks to a running
+[`palace-daemon`](https://github.com/jphein/palace-daemon) over HTTP.
+No filesystem access, no ChromaDB import, no shared-process constraint
+with the daemon. Use this adapter when MemPalace is fronted by the
+daemon (the daemon is the single writer to the palace) — the existing
+`mempalace` adapter is still correct for single-process upstream
+installs without the daemon.
 
-The fork-side adapter would talk only HTTP/MCP:
+**Wired endpoints:**
 
-- `get_graph_snapshot()` → POST `/mcp` with `mempalace_list_wings`,
-  `mempalace_list_rooms`, `mempalace_list_tunnels`,
-  `mempalace_kg_query`. Each tool returns structured data; the
-  adapter assembles the `(Entity, Edge)` graph from those calls.
-- `query()` → GET `/search?q=...&kind=...&limit=...` (via the
-  palace-daemon HTTP REST surface). Default `kind="content"` keeps
-  Stop-hook auto-save checkpoints out of the result set —
-  validated end-to-end against the canonical 151K-drawer palace on
-  2026-04-25, filter excludes ~637 / ~0.4% of corpus by count but
-  ~80%+ of search results before the filter.
-- No filesystem access, no ChromaDB import, no shared-process
-  constraint with the daemon.
+- `query()` → `GET /search?q=…&kind=…&limit=…` with `X-API-Key`. Default
+  `kind="content"` excludes Stop-hook auto-save checkpoints; pass
+  `--kind all` to disable. Daemon-side `warnings` (e.g. broken HNSW
+  index) are surfaced into `QueryResult.error` as `WARN: …` so Cat 9
+  scoring can distinguish flagged retrieval from clean retrieval.
+- `get_graph_snapshot()` → tries `GET /graph` first (palace-daemon
+  ≥1.6.0); on 404, falls back to walking `mempalace_list_wings`,
+  `mempalace_list_rooms` per wing, and `mempalace_list_tunnels` via
+  `POST /mcp`. The MCP fallback is slower (~30s on a 151K-drawer
+  palace) but works against any palace-daemon version.
 
-CLI invocation pattern:
+**Auth resolution:** explicit `--api-url` / `--api-key` flags →
+`~/.config/palace-daemon/env` (`PALACE_DAEMON_URL`, `PALACE_API_KEY`)
+→ process environment.
 
-    sme-eval cat9 --adapter mempalace-daemon \
-      --api-url http://your-daemon:8085 --subtest 9b
+**Invocation:**
 
-The existing `--api-url` flag pattern (used by the LadybugDB
-adapter) is the right shape; the new adapter just wires it through
-to palace-daemon endpoints instead of LadybugDB ones.
+```bash
+# With explicit daemon URL
+sme-eval retrieve --adapter mempalace-daemon \
+    --api-url http://your-daemon:8085 \
+    --questions corpus.yaml \
+    --kind content \
+    --json out.json
+
+# Or, if ~/.config/palace-daemon/env is populated, no flags needed
+sme-eval retrieve --adapter mempalace-daemon --questions corpus.yaml
+```
+
+The same `--api-url` / `--api-key` / `--kind` flags work on the
+`cat4`, `cat5`, and `check` subcommands.
 
 **Why this matters:** the engram-2 critique ("0.984 R@5 but 17% E2E
-QA accuracy") is about exactly the integration-under-production-model
-slice that Cat 9 measures. The fork's `kind="content"` filter is a
-candidate fix for one specific shape of that gap. Running SME Cat 9
-through the daemon — both before and after applying the kind=
-filter at the adapter layer — would let the framework's verdict
-replace our hand-rolled A/B and would generate publishable data on
-whether the fix moves the needle. **Multi-hour adapter build** —
-not yet started; documented here as the next concrete step in the
-SME-on-MemPalace integration story.
+QA accuracy") is about the integration-under-production-model slice
+that Cat 9 measures. Running SME's `retrieve` through the daemon
+surfaces exactly the kind of gap that critique describes — the
+adapter's WARN-soft-error treatment means the framework records
+"retrieval ran but the daemon flagged it as degraded" as a first-
+class signal, not as a hard failure that hides the issue.
 
-### Why the existing adapter still has a use
+#### Why the existing adapter still has a use
 
 For users running upstream MemPalace without palace-daemon (the
 default install pattern), the existing `mempalace` adapter is
 correct — single process, no daemon, direct ChromaDB access is
-fine. The fork adapter is *additive*, for users who've adopted
+fine. The daemon adapter is *additive*, for users who've adopted
 palace-daemon's single-writer architecture.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -144,6 +144,54 @@ correct — single process, no daemon, direct ChromaDB access is
 fine. The daemon adapter is *additive*, for users who've adopted
 palace-daemon's single-writer architecture.
 
+### Shipped: `familiar` adapter
+
+`sme/adapters/familiar.py` talks to a running
+[`familiar.realm.watch`](https://github.com/jphein/familiar.realm.watch)
+v0.2.0+ instance over HTTP. Familiar wraps palace-daemon with a v0.2
+retrieval pipeline (rerank, temporal decay, extractive compression,
+grounding directives). This adapter measures familiar's full pipeline;
+the sibling `mempalace-daemon` adapter measures palace alone.
+**Comparing their SME scores quantifies what familiar's v0.2
+pipeline contributes** to retrieval quality on top of the underlying
+daemon.
+
+**Wired endpoints:**
+
+- `query()` → `POST /api/familiar/eval` with body
+  `{query, limit, kind, mock}`. Familiar's eval endpoint already
+  returns SME-shape `{answer, context_string, retrieved_entities,
+  retrieved_edges, error, warnings, available_in_scope}` natively
+  (it was designed against the SME contract), so the adapter is
+  mostly deserialization with the same WARN: error-prefix
+  translation as `mempalace-daemon`.
+- `get_graph_snapshot()` → `GET /api/familiar/graph`. Familiar
+  proxies palace-daemon's `/graph` with a 5-minute server-side cache;
+  payload mapping reuses `sme/adapters/_graph_mapping.py` shared with
+  `mempalace-daemon`.
+- `get_harness_manifest()` → forward-compat for Cat 9. Returns
+  `[ToolCall, MCPResource]` once `sme.harness` ships; `[]` until then.
+
+**Determinism:** `--mock` (default) skips LLM inference so Cat 1
+substring scoring is reproducible across runs. Use `--no-mock` to
+include the model output in the per-question record (intended for
+future Cat 9 work).
+
+**Invocation:**
+
+```bash
+# Default: --mock for Cat 1 determinism
+sme-eval retrieve --adapter familiar     --api-url https://familiar.jphe.in     --questions corpus.yaml     --json familiar.json
+
+# Compare against the same palace via the daemon adapter
+sme-eval retrieve --adapter mempalace-daemon     --api-url http://your-daemon:8085     --questions corpus.yaml     --json daemon.json
+
+# The score delta = what familiar's v0.2 pipeline is worth
+```
+
+The `--api-url`, `--mock`/`--no-mock`, and `--familiar-timeout` flags
+work on `cat4`, `cat5`, `check`, and `retrieve` subcommands.
+
 ## License
 
 MIT. See [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -79,6 +79,67 @@ the documentation and code.
   Handshake) harness-integration spec. Reference material — read the
   onboarding guide first if you want to get a test run going.
 
+## Fork roadmap (jphein)
+
+This is a fork; planned fork-specific work below. Upstream is
+[M0nkeyFl0wer/multipass-structural-memory-eval](https://github.com/M0nkeyFl0wer/multipass-structural-memory-eval) — bug fixes and category contributions still target upstream.
+
+### Planned: `mempalace-daemon` adapter
+
+The shipped `sme/adapters/mempalace.py` opens ChromaDB directly via
+`chromadb.PersistentClient`. That works for upstream MemPalace
+single-process installs but **violates the daemon-strict invariant**
+of the [palace-daemon](https://github.com/jphein/palace-daemon) /
+[jphein/mempalace](https://github.com/jphein/mempalace) architecture
+where the daemon is the only process allowed to open the palace
+SQLite. Two `PersistentClient` instances against the same palace =
+the multi-writer corruption scenario the daemon was built to
+prevent. Even for SME's read-only adapter calls, holding ChromaDB
+file handles parallel to the daemon's writers is the wrong shape.
+
+The fork-side adapter would talk only HTTP/MCP:
+
+- `get_graph_snapshot()` → POST `/mcp` with `mempalace_list_wings`,
+  `mempalace_list_rooms`, `mempalace_list_tunnels`,
+  `mempalace_kg_query`. Each tool returns structured data; the
+  adapter assembles the `(Entity, Edge)` graph from those calls.
+- `query()` → GET `/search?q=...&kind=...&limit=...` (via the
+  palace-daemon HTTP REST surface). Default `kind="content"` keeps
+  Stop-hook auto-save checkpoints out of the result set —
+  validated end-to-end against the canonical 151K-drawer palace on
+  2026-04-25, filter excludes ~637 / ~0.4% of corpus by count but
+  ~80%+ of search results before the filter.
+- No filesystem access, no ChromaDB import, no shared-process
+  constraint with the daemon.
+
+CLI invocation pattern:
+
+    sme-eval cat9 --adapter mempalace-daemon \
+      --api-url http://your-daemon:8085 --subtest 9b
+
+The existing `--api-url` flag pattern (used by the LadybugDB
+adapter) is the right shape; the new adapter just wires it through
+to palace-daemon endpoints instead of LadybugDB ones.
+
+**Why this matters:** the engram-2 critique ("0.984 R@5 but 17% E2E
+QA accuracy") is about exactly the integration-under-production-model
+slice that Cat 9 measures. The fork's `kind="content"` filter is a
+candidate fix for one specific shape of that gap. Running SME Cat 9
+through the daemon — both before and after applying the kind=
+filter at the adapter layer — would let the framework's verdict
+replace our hand-rolled A/B and would generate publishable data on
+whether the fix moves the needle. **Multi-hour adapter build** —
+not yet started; documented here as the next concrete step in the
+SME-on-MemPalace integration story.
+
+### Why the existing adapter still has a use
+
+For users running upstream MemPalace without palace-daemon (the
+default install pattern), the existing `mempalace` adapter is
+correct — single process, no daemon, direct ChromaDB access is
+fine. The fork adapter is *additive*, for users who've adopted
+palace-daemon's single-writer architecture.
+
 ## License
 
 MIT. See [`LICENSE`](LICENSE).

--- a/baselines/jp_realm_v0_1_daemon_20260426.json
+++ b/baselines/jp_realm_v0_1_daemon_20260426.json
@@ -1,0 +1,700 @@
+{
+  "adapter": "mempalace-daemon",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1842,
+      "elapsed_ms": 1457.3,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 409,
+      "elapsed_ms": 543.3,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 308,
+      "elapsed_ms": 543.3,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 279,
+      "elapsed_ms": 659.0,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1328,
+      "elapsed_ms": 1063.2,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 770,
+      "elapsed_ms": 550.8,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 3025,
+      "elapsed_ms": 1929.1,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 161,
+      "elapsed_ms": 874.8,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 833,
+      "elapsed_ms": 735.1,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 458,
+      "elapsed_ms": 647.0,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1020,
+      "elapsed_ms": 428.5,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 481,
+      "elapsed_ms": 466.0,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 688,
+      "elapsed_ms": 487.0,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 379,
+      "elapsed_ms": 472.1,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1381,
+      "elapsed_ms": 1036.3,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 129,
+      "elapsed_ms": 485.3,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 203,
+      "elapsed_ms": 440.8,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 887,
+      "elapsed_ms": 742.1,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 760,
+      "elapsed_ms": 727.5,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 611,
+      "elapsed_ms": 482.8,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 442,
+      "elapsed_ms": 433.7,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 196,
+      "elapsed_ms": 438.9,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 292,
+      "elapsed_ms": 472.7,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1910,
+      "elapsed_ms": 1357.5,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 400,
+      "elapsed_ms": 785.2,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 483,
+      "elapsed_ms": 856.5,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1020,
+      "elapsed_ms": 709.8,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2698,
+      "elapsed_ms": 2497.6,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 830,
+      "elapsed_ms": 515.6,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 245,
+      "elapsed_ms": 451.1,
+      "retrieval_path": [
+        "kind=content",
+        "available_in_scope=151478",
+        "total_before_filter=100"
+      ],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 15,
+    "partial_hit": 27,
+    "mean_recall": 0.7,
+    "mean_tokens": 815.6,
+    "tokens_per_correct_answer": 1631.2,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7037037037037037,
+        "hit_rate": 0.8888888888888888,
+        "mean_tokens": 842.8148148148148
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 570.6666666666666
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_20260426.json
+++ b/baselines/jp_realm_v0_1_familiar_20260426.json
@@ -1,0 +1,575 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 341,
+      "elapsed_ms": 2053.9,
+      "retrieval_path": [],
+      "error": "WARN: palace_unreachable; low_confidence"
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 796,
+      "elapsed_ms": 1602.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 864.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 660,
+      "elapsed_ms": 745.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 880,
+      "elapsed_ms": 1891.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1157,
+      "elapsed_ms": 708.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 341,
+      "elapsed_ms": 2007.2,
+      "retrieval_path": [],
+      "error": "WARN: palace_unreachable; low_confidence"
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 543,
+      "elapsed_ms": 1359.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1073,
+      "elapsed_ms": 1681.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 843,
+      "elapsed_ms": 1215.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1273,
+      "elapsed_ms": 1109.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 810,
+      "elapsed_ms": 1659.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 1068,
+      "elapsed_ms": 1002.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 656,
+      "elapsed_ms": 1365.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1769,
+      "elapsed_ms": 1626.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 511,
+      "elapsed_ms": 1379.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 586,
+      "elapsed_ms": 1153.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1271,
+      "elapsed_ms": 1337.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 801,
+      "elapsed_ms": 1517.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 963,
+      "elapsed_ms": 1131.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 563,
+      "elapsed_ms": 1067.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 1066.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 673,
+      "elapsed_ms": 1171.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 341,
+      "elapsed_ms": 2007.3,
+      "retrieval_path": [],
+      "error": "WARN: palace_unreachable; low_confidence"
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 651,
+      "elapsed_ms": 1208.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 750,
+      "elapsed_ms": 858.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1315,
+      "elapsed_ms": 565.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 341,
+      "elapsed_ms": 2006.6,
+      "retrieval_path": [],
+      "error": "WARN: palace_unreachable; low_confidence"
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 876,
+      "elapsed_ms": 1309.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 630,
+      "elapsed_ms": 1035.7,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 16,
+    "partial_hit": 24,
+    "mean_recall": 0.6666666666666666,
+    "mean_tokens": 787.8,
+    "tokens_per_correct_answer": 1477.125,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 0.7777777777777778,
+        "mean_tokens": 777.5925925925926
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 879.6666666666666
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_20260426_v2.json
+++ b/baselines/jp_realm_v0_1_familiar_20260426_v2.json
@@ -1,0 +1,582 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2234,
+      "elapsed_ms": 1478.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 796,
+      "elapsed_ms": 551.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 449.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 660,
+      "elapsed_ms": 457.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 880,
+      "elapsed_ms": 1102.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1157,
+      "elapsed_ms": 548.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1691,
+      "elapsed_ms": 1873.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 543,
+      "elapsed_ms": 543.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1073,
+      "elapsed_ms": 463.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 843,
+      "elapsed_ms": 456.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1273,
+      "elapsed_ms": 451.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 810,
+      "elapsed_ms": 447.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 1068,
+      "elapsed_ms": 456.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 656,
+      "elapsed_ms": 608.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1769,
+      "elapsed_ms": 1448.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 511,
+      "elapsed_ms": 509.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 586,
+      "elapsed_ms": 453.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1271,
+      "elapsed_ms": 750.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 801,
+      "elapsed_ms": 740.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 963,
+      "elapsed_ms": 498.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 563,
+      "elapsed_ms": 810.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 453.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 673,
+      "elapsed_ms": 461.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 2302,
+      "elapsed_ms": 1357.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 651,
+      "elapsed_ms": 539.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 750,
+      "elapsed_ms": 448.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1315,
+      "elapsed_ms": 459.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1288,
+      "elapsed_ms": 2666.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 876,
+      "elapsed_ms": 694.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 630,
+      "elapsed_ms": 481.8,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 17,
+    "partial_hit": 27,
+    "mean_recall": 0.7333333333333333,
+    "mean_tokens": 992.8333333333334,
+    "tokens_per_correct_answer": 1752.0588235294117,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7407407407407407,
+        "hit_rate": 0.8888888888888888,
+        "mean_tokens": 1005.4074074074074
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 879.6666666666666
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_20260426_v3.json
+++ b/baselines/jp_realm_v0_1_familiar_20260426_v3.json
@@ -1,0 +1,585 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2234,
+      "elapsed_ms": 1434.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 796,
+      "elapsed_ms": 623.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 643.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 660,
+      "elapsed_ms": 739.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 880,
+      "elapsed_ms": 1239.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1157,
+      "elapsed_ms": 534.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1691,
+      "elapsed_ms": 1862.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 543,
+      "elapsed_ms": 524.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1073,
+      "elapsed_ms": 462.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 843,
+      "elapsed_ms": 578.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1273,
+      "elapsed_ms": 540.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 904,
+      "elapsed_ms": 436.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 1068,
+      "elapsed_ms": 466.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 656,
+      "elapsed_ms": 451.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1769,
+      "elapsed_ms": 1188.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 511,
+      "elapsed_ms": 519.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 586,
+      "elapsed_ms": 459.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1271,
+      "elapsed_ms": 758.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 801,
+      "elapsed_ms": 793.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 963,
+      "elapsed_ms": 449.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 563,
+      "elapsed_ms": 466.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 458.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 673,
+      "elapsed_ms": 461.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 2302,
+      "elapsed_ms": 1445.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 651,
+      "elapsed_ms": 534.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 750,
+      "elapsed_ms": 446.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1315,
+      "elapsed_ms": 856.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1288,
+      "elapsed_ms": 2269.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 876,
+      "elapsed_ms": 561.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 630,
+      "elapsed_ms": 441.8,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 18,
+    "partial_hit": 28,
+    "mean_recall": 0.7666666666666667,
+    "mean_tokens": 995.9666666666667,
+    "tokens_per_correct_answer": 1659.9444444444443,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7777777777777778,
+        "hit_rate": 0.9259259259259259,
+        "mean_tokens": 1008.8888888888889
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 879.6666666666666
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_20260426_v4_punct_fix.json
+++ b/baselines/jp_realm_v0_1_familiar_20260426_v4_punct_fix.json
@@ -1,0 +1,586 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2801,
+      "elapsed_ms": 1826.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 768,
+      "elapsed_ms": 990.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 735.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 660,
+      "elapsed_ms": 899.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 704,
+      "elapsed_ms": 752.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1157,
+      "elapsed_ms": 487.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1691,
+      "elapsed_ms": 3052.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 543,
+      "elapsed_ms": 500.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1073,
+      "elapsed_ms": 449.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 843,
+      "elapsed_ms": 444.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1273,
+      "elapsed_ms": 469.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 891,
+      "elapsed_ms": 474.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [
+        "GraphPalace"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1116,
+      "elapsed_ms": 1377.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 677,
+      "elapsed_ms": 527.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "rerank"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 682,
+      "elapsed_ms": 456.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 539,
+      "elapsed_ms": 440.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 566,
+      "elapsed_ms": 520.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 700,
+      "elapsed_ms": 447.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 565,
+      "elapsed_ms": 455.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 963,
+      "elapsed_ms": 465.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 563,
+      "elapsed_ms": 465.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 452.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 717,
+      "elapsed_ms": 598.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1705,
+      "elapsed_ms": 1308.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 651,
+      "elapsed_ms": 518.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 769,
+      "elapsed_ms": 464.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1368,
+      "elapsed_ms": 456.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1288,
+      "elapsed_ms": 1992.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 876,
+      "elapsed_ms": 528.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 630,
+      "elapsed_ms": 448.6,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 17,
+    "partial_hit": 29,
+    "mean_recall": 0.7666666666666667,
+    "mean_tokens": 931.0333333333333,
+    "tokens_per_correct_answer": 1643.0,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7777777777777778,
+        "hit_rate": 0.9629629629629629,
+        "mean_tokens": 933.1481481481482
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 912.0
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_v0.3.9_reflect_cumulative.json
+++ b/baselines/jp_realm_v0_1_familiar_v0.3.9_reflect_cumulative.json
@@ -1,0 +1,587 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2914,
+      "elapsed_ms": 1685.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 905,
+      "elapsed_ms": 657.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 713,
+      "elapsed_ms": 448.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 796,
+      "elapsed_ms": 459.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 841,
+      "elapsed_ms": 743.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1294,
+      "elapsed_ms": 456.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1827,
+      "elapsed_ms": 2044.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 679,
+      "elapsed_ms": 521.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1210,
+      "elapsed_ms": 503.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 980,
+      "elapsed_ms": 448.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1410,
+      "elapsed_ms": 444.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1027,
+      "elapsed_ms": 447.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [
+        "GraphPalace"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1252,
+      "elapsed_ms": 1529.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "hermes",
+        "agent"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 796,
+      "elapsed_ms": 491.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "rerank"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 819,
+      "elapsed_ms": 443.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 675,
+      "elapsed_ms": 447.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 703,
+      "elapsed_ms": 430.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 837,
+      "elapsed_ms": 445.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 702,
+      "elapsed_ms": 493.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1099,
+      "elapsed_ms": 424.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 700,
+      "elapsed_ms": 577.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 713,
+      "elapsed_ms": 618.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 854,
+      "elapsed_ms": 423.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1842,
+      "elapsed_ms": 991.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 787,
+      "elapsed_ms": 546.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 905,
+      "elapsed_ms": 771.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1190,
+      "elapsed_ms": 470.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1425,
+      "elapsed_ms": 2087.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1020,
+      "elapsed_ms": 564.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 766,
+      "elapsed_ms": 467.4,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 18,
+    "partial_hit": 29,
+    "mean_recall": 0.7833333333333333,
+    "mean_tokens": 1056.0333333333333,
+    "tokens_per_correct_answer": 1760.0555555555557,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7962962962962963,
+        "hit_rate": 0.9629629629629629,
+        "mean_tokens": 1068.5185185185185
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 943.6666666666666
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_v0.3_candidate_window.json
+++ b/baselines/jp_realm_v0_1_familiar_v0.3_candidate_window.json
@@ -1,0 +1,580 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 3323,
+      "elapsed_ms": 4851.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 857,
+      "elapsed_ms": 1165.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 566,
+      "elapsed_ms": 526.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1104,
+      "elapsed_ms": 726.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 881,
+      "elapsed_ms": 1111.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1343,
+      "elapsed_ms": 482.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 341,
+      "elapsed_ms": 5006.8,
+      "retrieval_path": [],
+      "error": "WARN: palace_unreachable; low_confidence"
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 857,
+      "elapsed_ms": 856.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1263,
+      "elapsed_ms": 848.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1193,
+      "elapsed_ms": 700.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1147,
+      "elapsed_ms": 426.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 955,
+      "elapsed_ms": 477.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [
+        "GraphPalace"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1116,
+      "elapsed_ms": 1042.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 784,
+      "elapsed_ms": 1084.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1140,
+      "elapsed_ms": 531.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 539,
+      "elapsed_ms": 409.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 702,
+      "elapsed_ms": 1052.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 3423,
+      "elapsed_ms": 1992.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1232,
+      "elapsed_ms": 1384.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1121,
+      "elapsed_ms": 515.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 533,
+      "elapsed_ms": 1367.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1346,
+      "elapsed_ms": 1725.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 699,
+      "elapsed_ms": 507.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 3425,
+      "elapsed_ms": 4412.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 754,
+      "elapsed_ms": 494.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1352,
+      "elapsed_ms": 432.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1289,
+      "elapsed_ms": 429.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 341,
+      "elapsed_ms": 5006.1,
+      "retrieval_path": [],
+      "error": "WARN: palace_unreachable; low_confidence"
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 961,
+      "elapsed_ms": 924.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 691,
+      "elapsed_ms": 976.8,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 17,
+    "partial_hit": 26,
+    "mean_recall": 0.7166666666666667,
+    "mean_tokens": 1175.9333333333334,
+    "tokens_per_correct_answer": 2075.176470588235,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7222222222222222,
+        "hit_rate": 0.8518518518518519,
+        "mean_tokens": 1205.037037037037
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 914.0
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_v0.3_reflect.json
+++ b/baselines/jp_realm_v0_1_familiar_v0.3_reflect.json
@@ -1,0 +1,587 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2801,
+      "elapsed_ms": 1740.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 768,
+      "elapsed_ms": 500.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 466.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 660,
+      "elapsed_ms": 498.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 704,
+      "elapsed_ms": 742.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1157,
+      "elapsed_ms": 523.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1691,
+      "elapsed_ms": 1998.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 543,
+      "elapsed_ms": 550.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1073,
+      "elapsed_ms": 438.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 843,
+      "elapsed_ms": 440.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1273,
+      "elapsed_ms": 448.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 891,
+      "elapsed_ms": 445.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [
+        "GraphPalace"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1116,
+      "elapsed_ms": 1086.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "hermes",
+        "agent"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 659,
+      "elapsed_ms": 515.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "rerank"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 682,
+      "elapsed_ms": 468.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 539,
+      "elapsed_ms": 446.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 566,
+      "elapsed_ms": 455.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 700,
+      "elapsed_ms": 443.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 565,
+      "elapsed_ms": 431.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 963,
+      "elapsed_ms": 453.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 563,
+      "elapsed_ms": 446.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 454.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 717,
+      "elapsed_ms": 446.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1705,
+      "elapsed_ms": 1074.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 651,
+      "elapsed_ms": 506.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 769,
+      "elapsed_ms": 463.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1368,
+      "elapsed_ms": 469.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1288,
+      "elapsed_ms": 2018.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 876,
+      "elapsed_ms": 507.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 630,
+      "elapsed_ms": 441.1,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 18,
+    "partial_hit": 29,
+    "mean_recall": 0.7833333333333333,
+    "mean_tokens": 930.4333333333333,
+    "tokens_per_correct_answer": 1550.7222222222222,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7962962962962963,
+        "hit_rate": 0.9629629629629629,
+        "mean_tokens": 932.4814814814815
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 912.0
+      }
+    }
+  }
+}

--- a/baselines/jp_realm_v0_1_familiar_v0.3_task1_bm25.json
+++ b/baselines/jp_realm_v0_1_familiar_v0.3_task1_bm25.json
@@ -1,0 +1,586 @@
+{
+  "adapter": "familiar",
+  "db_path": null,
+  "collection_name": null,
+  "corpus_version": "jp-realm-v0.1",
+  "n_results": 5,
+  "questions": [
+    {
+      "id": "q01_familiar_what",
+      "text": "What is familiar.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "familiar",
+        "palace"
+      ],
+      "matched_sources": [
+        "familiar",
+        "palace"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 2801,
+      "elapsed_ms": 1982.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q02_realm_sigil_role",
+      "text": "What does realm-sigil do across JP's projects?",
+      "min_hops": 1,
+      "expected_sources": [
+        "sigil",
+        "version"
+      ],
+      "matched_sources": [
+        "sigil",
+        "version"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 768,
+      "elapsed_ms": 537.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q03_status_realm_watch",
+      "text": "What is status.realm.watch and what does it monitor?",
+      "min_hops": 1,
+      "expected_sources": [
+        "status",
+        "realm"
+      ],
+      "matched_sources": [
+        "status",
+        "realm"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 426.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q04_os_realm_watch",
+      "text": "What is os.realm.watch?",
+      "min_hops": 1,
+      "expected_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "matched_sources": [
+        "os.realm",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 660,
+      "elapsed_ms": 411.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q05_portal_realm",
+      "text": "What does the realm-portal VM serve?",
+      "min_hops": 1,
+      "expected_sources": [
+        "portal",
+        "VM"
+      ],
+      "matched_sources": [
+        "portal",
+        "VM"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 704,
+      "elapsed_ms": 708.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q06_mempalace_fork",
+      "text": "What are the key features of JP's mempalace fork vs upstream?",
+      "min_hops": 1,
+      "expected_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "matched_sources": [
+        "mempalace",
+        "fork"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1157,
+      "elapsed_ms": 470.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q07_palace_daemon_role",
+      "text": "What is palace-daemon for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "daemon",
+        "HTTP"
+      ],
+      "matched_sources": [
+        "daemon"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1691,
+      "elapsed_ms": 1986.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q08_kind_filter",
+      "text": "What does the kind=content search filter do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "kind",
+        "checkpoint"
+      ],
+      "matched_sources": [],
+      "recall": 0.0,
+      "hit": false,
+      "tokens": 543,
+      "elapsed_ms": 453.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q09_silent_save",
+      "text": "What is the /silent-save endpoint?",
+      "min_hops": 1,
+      "expected_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "matched_sources": [
+        "silent-save",
+        "diary"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1073,
+      "elapsed_ms": 523.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q10_hnsw_rebuild",
+      "text": "How do you rebuild the HNSW index when search recall is degraded?",
+      "min_hops": 1,
+      "expected_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "matched_sources": [
+        "HNSW",
+        "rebuild"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 843,
+      "elapsed_ms": 469.1,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q11_multipass_role",
+      "text": "What is multipass-structural-memory-eval?",
+      "min_hops": 1,
+      "expected_sources": [
+        "multipass",
+        "eval"
+      ],
+      "matched_sources": [
+        "multipass",
+        "eval"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1273,
+      "elapsed_ms": 467.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q12_rlm_paper",
+      "text": "What is the rlm (Recursive Language Models) project about?",
+      "min_hops": 1,
+      "expected_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "matched_sources": [
+        "rlm",
+        "recursive"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 891,
+      "elapsed_ms": 400.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q13_graphpalace",
+      "text": "What is GraphPalace and how does its pheromone model work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "GraphPalace",
+        "pheromone"
+      ],
+      "matched_sources": [
+        "GraphPalace"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1116,
+      "elapsed_ms": 1142.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q14_hermes_agent",
+      "text": "What is hermes-agent?",
+      "min_hops": 1,
+      "expected_sources": [
+        "hermes",
+        "agent"
+      ],
+      "matched_sources": [
+        "agent"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 677,
+      "elapsed_ms": 498.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q15_context_engine_emmimal",
+      "text": "What is the Emmimal context-engine framework?",
+      "min_hops": 1,
+      "expected_sources": [
+        "context-engine",
+        "rerank"
+      ],
+      "matched_sources": [
+        "rerank"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 682,
+      "elapsed_ms": 417.9,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q16_speech_to_cli",
+      "text": "What does speech-to-cli do?",
+      "min_hops": 1,
+      "expected_sources": [
+        "speech",
+        "voice"
+      ],
+      "matched_sources": [
+        "speech",
+        "voice"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 539,
+      "elapsed_ms": 445.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q17_vault_gate",
+      "text": "What is vault-gate and how does it unlock Vaultwarden?",
+      "min_hops": 1,
+      "expected_sources": [
+        "vault-gate",
+        "bw"
+      ],
+      "matched_sources": [
+        "vault-gate"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 566,
+      "elapsed_ms": 416.8,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q18_cc_switcher",
+      "text": "What is the cc tool used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "matched_sources": [
+        "claude-code-switcher",
+        "provider"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 700,
+      "elapsed_ms": 405.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q19_outline_wiki",
+      "text": "What is JP's Outline wiki used for?",
+      "min_hops": 1,
+      "expected_sources": [
+        "outline",
+        "documentation"
+      ],
+      "matched_sources": [
+        "outline"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 565,
+      "elapsed_ms": 416.0,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q20_realm_optimizer",
+      "text": "What is realm-optimizer?",
+      "min_hops": 1,
+      "expected_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "matched_sources": [
+        "optimizer",
+        "quest"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 963,
+      "elapsed_ms": 412.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q21_gatekeeper_router",
+      "text": "What is the gatekeeper firewall and what does it run?",
+      "min_hops": 1,
+      "expected_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "matched_sources": [
+        "gatekeeper",
+        "OpenWrt"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 563,
+      "elapsed_ms": 522.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q22_ubox0_caddy",
+      "text": "What does ubox0 serve via Caddy?",
+      "min_hops": 1,
+      "expected_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "matched_sources": [
+        "ubox0",
+        "Caddy"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 576,
+      "elapsed_ms": 463.3,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q23_disks_services",
+      "text": "What services run on the disks host?",
+      "min_hops": 2,
+      "expected_sources": [
+        "disks",
+        "palace-daemon"
+      ],
+      "matched_sources": [
+        "disks"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 717,
+      "elapsed_ms": 451.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q24_katana_role",
+      "text": "What is the role of katana in JP's homelab?",
+      "min_hops": 1,
+      "expected_sources": [
+        "katana",
+        "GPU"
+      ],
+      "matched_sources": [
+        "katana"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 1705,
+      "elapsed_ms": 1011.6,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q25_vlans_collectd",
+      "text": "How is JP's network organized in VLANs?",
+      "min_hops": 2,
+      "expected_sources": [
+        "VLAN",
+        "collectd"
+      ],
+      "matched_sources": [
+        "VLAN"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 651,
+      "elapsed_ms": 660.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q26_caddy_dns_resolvers",
+      "text": "What was the Caddy ACME DNS-01 cert renewal issue and the fix?",
+      "min_hops": 1,
+      "expected_sources": [
+        "resolvers",
+        "dns-01"
+      ],
+      "matched_sources": [
+        "resolvers"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 769,
+      "elapsed_ms": 587.4,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q27_v02_retrieval_pipeline",
+      "text": "What does familiar v0.2's retrieval pipeline do?",
+      "min_hops": 2,
+      "expected_sources": [
+        "rerank",
+        "decay"
+      ],
+      "matched_sources": [
+        "rerank",
+        "decay"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1368,
+      "elapsed_ms": 685.5,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q28_postgres_migration",
+      "text": "What is the planned palace storage migration to Postgres?",
+      "min_hops": 1,
+      "expected_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "matched_sources": [
+        "Postgres",
+        "pgvector"
+      ],
+      "recall": 1.0,
+      "hit": true,
+      "tokens": 1288,
+      "elapsed_ms": 2025.7,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q29_p40_upgrade",
+      "text": "What is the planned P40 GPU upgrade for the familiar host?",
+      "min_hops": 1,
+      "expected_sources": [
+        "P40",
+        "VRAM"
+      ],
+      "matched_sources": [
+        "P40"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 876,
+      "elapsed_ms": 478.2,
+      "retrieval_path": [],
+      "error": null
+    },
+    {
+      "id": "q30_techempower",
+      "text": "What is JP's TechEmpower work?",
+      "min_hops": 1,
+      "expected_sources": [
+        "TechEmpower",
+        "technology"
+      ],
+      "matched_sources": [
+        "TechEmpower"
+      ],
+      "recall": 0.5,
+      "hit": true,
+      "tokens": 630,
+      "elapsed_ms": 420.0,
+      "retrieval_path": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "total": 30,
+    "full_recall": 17,
+    "partial_hit": 29,
+    "mean_recall": 0.7666666666666667,
+    "mean_tokens": 931.0333333333333,
+    "tokens_per_correct_answer": 1643.0,
+    "by_hop": {
+      "1": {
+        "n": 27,
+        "mean_recall": 0.7777777777777778,
+        "hit_rate": 0.9629629629629629,
+        "mean_tokens": 933.1481481481482
+      },
+      "2": {
+        "n": 3,
+        "mean_recall": 0.6666666666666666,
+        "hit_rate": 1.0,
+        "mean_tokens": 912.0
+      }
+    }
+  }
+}

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -394,6 +394,42 @@ soon as the harness types ship.
 
 ---
 
+## Lessons from the first live eval — 2026-04-26
+
+The first end-to-end eval against a real 151K-drawer palace (familiar
+v0.2.0 → v0.2.1, jp-realm-v0.1 corpus) surfaced lessons that should
+shape future adapter work and category implementations:
+
+- **Substring scoring on `context_string` is the right MVP.** Mock
+  inference + literal-substring expected-source matching produced a
+  deterministic, reproducible signal that worked across two adapters
+  (`familiar`, `mempalace-daemon`) without a judge. v0.1 corpus
+  required ~30 min to author and produced actionable findings within
+  one hour. Don't chase Cat 9 LLM-judge complexity until substring
+  scoring plateaus.
+- **The eval distinguishes "system gap" from "pipeline gap".** When
+  q12 (rlm) and q13 (GraphPalace) initially scored 0.0 we couldn't
+  tell whether the palace lacked the content or whether retrieval was
+  failing. Writing the missing drawers via `palace-daemon /memory`
+  and re-running flipped q12 to 1.0 (palace gap) but left q13 at 0.0
+  (pipeline gap — embedding ranking issue). This split is the
+  diagnostic the framework was built to provide; it lands cleanly
+  with the simplest possible scoring.
+- **The corpus is a ratchet, not a benchmark.** Running the same
+  corpus before vs after a one-line client-side fix (palace-client
+  punctuation strip, `b676852`) showed a +0.50 question delta in
+  ~2 minutes. v0.1 corpora should be cheap enough to run on every
+  retrieval-pipeline PR.
+- **`retrieve` subcommand needed CLI plumbing fixes the helpers
+  hid.** The `read_only` kwarg and `--mock`/`--familiar-timeout`
+  flags only worked through `_load_adapter_from_args` (cat4/cat5
+  paths) but not through `cmd_retrieve`'s inline construction.
+  Bundle adapter-arg expansion through a single helper across all
+  subcommands rather than re-implementing in each.
+- **Per-corpus directories worked.** `sme/corpora/jp_realm_v0_1/`
+  and `baselines/jp_realm_v0_1_*.json` made it obvious where to
+  add `jp_realm_v0_2`, `family_palace_v0_1`, etc. Don't refactor.
+
 ## What's next
 
 ### Categories that aren't implemented yet

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -376,6 +376,21 @@ any specific SME output as gospel:
   what happens in production under a specific model and harness.
   See Cat 9 in the spec for why this is the largest gap in current
   instrumentation.
+**Forward-compat in adapters (2026-04-26):** `FamiliarAdapter`
+(familiar.realm.watch v0.2's adapter) emits per-question records that
+include the verbatim `context_string` sent to inference plus structured
+`warnings` (`palace_unreachable`, `low_confidence`,
+`filtered_null_text_*`, `stuck_loop`). The `cmd_retrieve` JSON output
+captures all of this per-question, so a future
+`sme/categories/handshake.py` scorer can compute Cat 9 metrics
+(9a invocation rate, 9b call-through success, 9c result usage,
+9d negative-control rate) from existing run artifacts without
+revisiting the adapter API. `get_harness_manifest()` is also
+implemented forward-compat — currently returns `[]` because this
+multipass version doesn't import `sme.harness.HarnessDescriptor`,
+but two descriptors (HTTP `ToolCall` + `MCPResource`) are emitted as
+soon as the harness types ship.
+
 
 ---
 

--- a/docs/superpowers/plans/2026-04-25-mempalace-daemon-adapter.md
+++ b/docs/superpowers/plans/2026-04-25-mempalace-daemon-adapter.md
@@ -1,0 +1,2115 @@
+# `mempalace-daemon` adapter implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new SME adapter `MemPalaceDaemonAdapter` that talks to a running `palace-daemon` over HTTP, with `query()` driving `/search` and `get_graph_snapshot()` driving `/graph` (with MCP fallback). Ship the SME side independently of the daemon side; the existing direct-ChromaDB `MemPalaceAdapter` is left untouched.
+
+**Architecture:** New file `sme/adapters/mempalace_daemon.py` implementing `SMEAdapter`. Auth and URL resolved from kwargs → `~/.config/palace-daemon/env` → process env. CLI gains `--api-key` and `--kind` flags wired through `_load_adapter` and `_load_adapter_from_args`. Tests mock `urllib.request.urlopen`; an integration suite is gated on `PALACE_DAEMON_URL` so CI does not require a live daemon.
+
+**Tech Stack:** Python 3.10+, `urllib` (stdlib, no new deps), pytest 8, FastAPI (only for understanding the daemon — we don't import it).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-25-mempalace-daemon-adapter-design.md`
+
+---
+
+## File structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `sme/adapters/mempalace_daemon.py` | Create | `MemPalaceDaemonAdapter` class — HTTP client, snapshot projection, ontology reporter |
+| `tests/conftest.py` | Modify | Add `fake_urlopen_factory` fixture for mocking HTTP responses without per-test boilerplate |
+| `tests/test_mempalace_daemon_adapter.py` | Create | Unit tests, all mocked |
+| `tests/test_mempalace_daemon_integration.py` | Create | Live-daemon smoke tests, gated on `PALACE_DAEMON_URL` |
+| `tests/fixtures/tiny_questions.yaml` | Create | 2-question YAML for end-to-end CLI smoke |
+| `sme/cli.py` | Modify | New `_load_adapter` branch (~line 60); new `--api-key`/`--kind` flags in `_add_db_or_api_args` (~line 464) and in `cmd_retrieve`'s subparser (~line 1056); thread `api_key`/`kind`/`api_url` through `_load_adapter_from_args` (~line 437) and `cmd_retrieve` adapter construction (~line 746) |
+| `README.md` | Modify | Replace "Planned: `mempalace-daemon` adapter" subsection with shipped status + invocation example |
+
+The adapter is one file because the class is cohesive and not large enough to justify splitting (estimated ~300 lines including docstrings). Test file is one file for the same reason.
+
+---
+
+## Conventions used in every task
+
+- **Working directory:** `/home/jp/Projects/multipass-structural-memory-eval` (the repo root). All paths in this plan are relative to the repo root unless absolute.
+- **Test runner:** `pytest` (already installed via `pip install -e ".[dev]"`).
+- **Commit style:** Conventional commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`). Each task ends with a single commit unless the task explicitly says otherwise.
+- **No `git add -A`.** Stage by exact path.
+- **Trailer:** every commit ends with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` per CLAUDE.md.
+
+---
+
+## Task 1: Test scaffolding — fake-urlopen fixture
+
+**Why first:** Every adapter test will need to mock `urllib.request.urlopen`. Build the helper once, reuse everywhere. Eliminates per-test boilerplate.
+
+**Files:**
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Read the existing conftest.py to confirm its current shape**
+
+Run: `cat tests/conftest.py`
+
+Expected: file exports `gap_graph` and `duplicates_graph` fixtures. Don't modify those — append.
+
+- [ ] **Step 2: Append the fake-urlopen fixture and helpers**
+
+Add to the end of `tests/conftest.py`:
+
+```python
+import io
+import json
+import urllib.error
+
+
+class _FakeResponse:
+    """Minimal stand-in for urlopen()'s return value.
+
+    Mocks the context-manager + .read() shape that the adapter uses.
+    """
+
+    def __init__(self, body, status=200):
+        if isinstance(body, (dict, list)):
+            body = json.dumps(body)
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        self._buf = io.BytesIO(body)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._buf.read()
+
+
+@pytest.fixture
+def fake_urlopen_factory(monkeypatch):
+    """Build a fake urlopen that returns canned responses per URL.
+
+    Usage::
+
+        fake_urlopen_factory({
+            "GET http://daemon/search?q=hi&limit=5&kind=content": {"results": [...]},
+            "POST http://daemon/mcp": {"result": {"content": [...]}},
+        })
+
+    The key is ``"<METHOD> <full URL up to but not including any extra query>"``.
+    Match is by exact prefix on the URL — query strings are compared in full
+    when present in the key, otherwise the prefix wins.
+
+    A response value can be:
+    * dict/list — JSON-encoded as 200 OK
+    * str/bytes — sent as-is, 200 OK
+    * tuple ``(status, body)`` — explicit status
+    * Exception — raised when the URL is hit
+    """
+
+    def factory(routes):
+        def fake_urlopen(req, timeout=None):
+            method = req.get_method()
+            url = req.full_url
+            key_full = f"{method} {url}"
+            # Try exact match, then prefix match without query
+            if key_full in routes:
+                resp = routes[key_full]
+            else:
+                base = url.split("?", 1)[0]
+                key_base = f"{method} {base}"
+                if key_base in routes:
+                    resp = routes[key_base]
+                else:
+                    raise AssertionError(f"unexpected request: {key_full}")
+            if isinstance(resp, Exception):
+                raise resp
+            if isinstance(resp, tuple):
+                status, body = resp
+                return _FakeResponse(body, status=status)
+            return _FakeResponse(resp)
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        return fake_urlopen
+
+    return factory
+```
+
+- [ ] **Step 3: Sanity-check that the fixture imports cleanly**
+
+Run: `pytest tests/ --collect-only -q 2>&1 | head -20`
+
+Expected: collection succeeds, no ImportError.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/conftest.py
+git commit -m "$(cat <<'EOF'
+test: add fake_urlopen_factory fixture for HTTP-mocking adapter tests
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Adapter file skeleton + auth resolution
+
+**Why:** Get the import path and constructor working before any HTTP code. Auth resolution has three sources and is the most likely place for a config bug.
+
+**Files:**
+- Create: `sme/adapters/mempalace_daemon.py`
+- Create: `tests/test_mempalace_daemon_adapter.py`
+
+- [ ] **Step 1: Write failing tests for auth resolution**
+
+Create `tests/test_mempalace_daemon_adapter.py`:
+
+```python
+"""Tests for sme.adapters.mempalace_daemon — HTTP-mocked, no live daemon."""
+
+from __future__ import annotations
+
+import os
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+
+
+# --- Auth resolution -------------------------------------------------
+
+
+def test_auth_explicit_kwargs_win(monkeypatch, tmp_path):
+    env_file = tmp_path / "env"
+    env_file.write_text("PALACE_API_KEY=from-file\nPALACE_DAEMON_URL=http://from-file\n")
+    monkeypatch.setenv("PALACE_API_KEY", "from-env")
+    monkeypatch.setenv("PALACE_DAEMON_URL", "http://from-env")
+
+    a = MemPalaceDaemonAdapter(
+        api_url="http://explicit",
+        api_key="explicit-key",
+        env_file=env_file,
+    )
+    assert a.api_url == "http://explicit"
+    assert a.api_key == "explicit-key"
+
+
+def test_auth_env_file_used_when_no_kwargs(monkeypatch, tmp_path):
+    env_file = tmp_path / "env"
+    env_file.write_text(
+        'PALACE_API_KEY="from-file"\nPALACE_DAEMON_URL=http://from-file:8085\n'
+    )
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+
+    a = MemPalaceDaemonAdapter(env_file=env_file)
+    assert a.api_url == "http://from-file:8085"
+    assert a.api_key == "from-file"
+
+
+def test_auth_process_env_used_when_env_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("PALACE_API_KEY", "from-env")
+    monkeypatch.setenv("PALACE_DAEMON_URL", "http://from-env:8085")
+
+    a = MemPalaceDaemonAdapter(env_file=tmp_path / "does-not-exist")
+    assert a.api_url == "http://from-env:8085"
+    assert a.api_key == "from-env"
+
+
+def test_auth_raises_when_nothing_resolves(monkeypatch, tmp_path):
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+
+    with pytest.raises(ValueError, match="api_url"):
+        MemPalaceDaemonAdapter(env_file=tmp_path / "nope")
+
+
+def test_auth_url_trailing_slash_is_stripped(monkeypatch, tmp_path):
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+    a = MemPalaceDaemonAdapter(
+        api_url="http://example/",
+        api_key="k",
+        env_file=tmp_path / "nope",
+    )
+    assert a.api_url == "http://example"
+```
+
+- [ ] **Step 2: Run the tests; verify all fail with ImportError**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x 2>&1 | tail -20`
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'sme.adapters.mempalace_daemon'`.
+
+- [ ] **Step 3: Create the adapter file with skeleton + auth resolution**
+
+Create `sme/adapters/mempalace_daemon.py`:
+
+```python
+"""MemPalace daemon HTTP adapter for SME.
+
+Talks to a running palace-daemon (https://github.com/jphein/palace-daemon)
+over HTTP. Unlike sme.adapters.mempalace.MemPalaceAdapter (which opens
+ChromaDB directly), this adapter does NO filesystem access and holds NO
+parallel handles to the palace SQLite — it only makes HTTP requests.
+
+Use this adapter when:
+* you run palace-daemon (the daemon is the single writer to the palace),
+* OR you want SME's structural readings to flow through the same
+  retrieval path your production agents use.
+
+For single-process MemPalace installs without the daemon, the existing
+MemPalaceAdapter is correct — direct ChromaDB access is fine when there
+is no concurrent writer to fight with.
+
+See ``docs/superpowers/specs/2026-04-25-mempalace-daemon-adapter-design.md``
+for the full design.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Optional
+
+from sme.adapters.base import Edge, Entity, QueryResult, SMEAdapter
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_ENV_FILE = "~/.config/palace-daemon/env"
+DEFAULT_KIND = "content"
+DEFAULT_TIMEOUT = 180.0  # seconds — list_wings on a 151K-drawer palace ~30s
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Minimal KEY=VALUE parser. Strips surrounding double-quotes.
+
+    Ignores blank lines and ``# ...`` comments. Does NOT do shell expansion;
+    the daemon's env file is a flat key/value list, not a shell script.
+    """
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        if val and val[0] == val[-1] and val[0] in ('"', "'"):
+            val = val[1:-1]
+        out[key] = val
+    return out
+
+
+class MemPalaceDaemonAdapter(SMEAdapter):
+    """SMEAdapter against a running palace-daemon HTTP API.
+
+    Construction does not connect — auth is resolved eagerly but the first
+    network call happens in ``query()`` or ``get_graph_snapshot()``.
+
+    Args:
+        api_url: Daemon base URL (e.g. ``http://disks.jphe.in:8085``).
+            Trailing slash stripped.
+        api_key: Sent as ``X-API-Key`` header on every request.
+        env_file: Path to an env file with ``PALACE_DAEMON_URL`` /
+            ``PALACE_API_KEY``. Defaults to ``~/.config/palace-daemon/env``.
+        kind: Default ``kind`` filter for ``/search``. ``"content"``
+            (default) excludes Stop-hook auto-save checkpoints; pass
+            ``"all"`` to disable, ``"checkpoint"`` for snapshot-only.
+        api_timeout: Per-request HTTP timeout in seconds.
+        prefer_graph_endpoint: If True (default), ``get_graph_snapshot``
+            tries ``GET /graph`` first; on 404 it falls back to walking
+            the four MCP tools. Set False to force the MCP path.
+        read_only: Accepted for CLI parity. Ignored — this adapter only
+            reads via HTTP.
+        db_path: Accepted for CLI parity. Ignored — daemon owns the file.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        env_file: Optional[str | Path] = None,
+        kind: str = DEFAULT_KIND,
+        api_timeout: float = DEFAULT_TIMEOUT,
+        prefer_graph_endpoint: bool = True,
+        read_only: bool = True,
+        db_path: Optional[str] = None,
+    ) -> None:
+        self.kind = kind
+        self.api_timeout = api_timeout
+        self.prefer_graph_endpoint = prefer_graph_endpoint
+
+        env_path = Path(os.path.expanduser(str(env_file or DEFAULT_ENV_FILE)))
+        env_vars = _parse_env_file(env_path)
+
+        resolved_url = (
+            api_url
+            or env_vars.get("PALACE_DAEMON_URL")
+            or os.environ.get("PALACE_DAEMON_URL")
+        )
+        resolved_key = (
+            api_key
+            or env_vars.get("PALACE_API_KEY")
+            or os.environ.get("PALACE_API_KEY")
+        )
+
+        if not resolved_url:
+            raise ValueError(
+                "MemPalaceDaemonAdapter needs api_url. Pass it explicitly, "
+                f"set PALACE_DAEMON_URL in {env_path}, or export it in the "
+                "environment."
+            )
+        if not resolved_key:
+            raise ValueError(
+                "MemPalaceDaemonAdapter needs api_key. Pass it explicitly, "
+                f"set PALACE_API_KEY in {env_path}, or export it in the "
+                "environment."
+            )
+
+        self.api_url = resolved_url.rstrip("/")
+        self.api_key = resolved_key
+
+    # --- SMEAdapter required methods ---------------------------------
+
+    def ingest_corpus(self, corpus: list[dict]) -> dict:
+        raise NotImplementedError(
+            "MemPalaceDaemonAdapter is diagnostic-only (Mode B). To seed a "
+            "test palace, use the daemon's /memory POST endpoint or the "
+            "mempalace CLI directly."
+        )
+
+    def query(self, question: str, **_kwargs: Any) -> QueryResult:
+        raise NotImplementedError("Implemented in a later task")
+
+    def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
+        raise NotImplementedError("Implemented in a later task")
+
+    def close(self) -> None:
+        pass
+```
+
+- [ ] **Step 4: Re-run the auth tests; verify they pass**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v 2>&1 | tail -20`
+
+Expected: all 5 auth tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py
+git commit -m "$(cat <<'EOF'
+feat(adapters): scaffold MemPalaceDaemonAdapter with auth resolution
+
+Three-source auth resolution: kwargs > env file > process env. Raises
+ValueError at construction if nothing resolves. query() and
+get_graph_snapshot() raise NotImplementedError pending follow-on tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `query()` happy path
+
+**Files:**
+- Modify: `sme/adapters/mempalace_daemon.py`
+- Modify: `tests/test_mempalace_daemon_adapter.py`
+
+- [ ] **Step 1: Write failing tests for query() success cases**
+
+Append to `tests/test_mempalace_daemon_adapter.py`:
+
+```python
+# --- query() ---------------------------------------------------------
+
+
+_OK_ENVELOPE = {
+    "query": "memory",
+    "filters": {"wing": None, "room": None},
+    "total_before_filter": 3,
+    "available_in_scope": 150811,
+    "warnings": [],
+    "results": [
+        {
+            "text": "first chunk text",
+            "metadata": {
+                "wing": "memorypalace",
+                "room": "architecture",
+                "source_file": "/path/to/notes.md",
+            },
+            "score": 0.91,
+        },
+        {
+            "text": "second chunk",
+            "metadata": {
+                "wing": "memorypalace",
+                "room": "diary",
+                "source_file": "/path/to/diary.md",
+            },
+            "score": 0.84,
+        },
+    ],
+}
+
+
+def _adapter(monkeypatch, tmp_path, **kwargs):
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+    defaults = dict(
+        api_url="http://daemon",
+        api_key="key",
+        env_file=tmp_path / "no-env",
+    )
+    defaults.update(kwargs)
+    return MemPalaceDaemonAdapter(**defaults)
+
+
+def test_query_success_builds_context_string(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error is None
+    assert "[1] [memorypalace/architecture]" in result.context_string
+    assert "first chunk text" in result.context_string
+    assert "[2] [memorypalace/diary]" in result.context_string
+    assert "second chunk" in result.context_string
+    # Source filename basenames, not full paths
+    assert "notes.md" in result.context_string
+    assert "/path/to/notes.md" not in result.context_string
+
+
+def test_query_retrieved_entities_have_wing_room_score(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert len(result.retrieved_entities) == 2
+    e0 = result.retrieved_entities[0]
+    assert e0.entity_type == "drawer:architecture"
+    assert e0.properties["wing"] == "memorypalace"
+    assert e0.properties["room"] == "architecture"
+    assert e0.properties["score"] == 0.91
+
+
+def test_query_retrieval_path_includes_kind_and_counts(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    path_str = "; ".join(result.retrieval_path)
+    assert "kind=content" in path_str
+    assert "available_in_scope=150811" in path_str
+    assert "total_before_filter=3" in path_str
+
+
+def test_query_kind_kwarg_overrides_default(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=all": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)  # kind defaults to "content"
+    result = a.query("memory", kind="all")
+    assert "kind=all" in "; ".join(result.retrieval_path)
+
+
+def test_query_n_results_threads_through_to_limit(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=12&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory", n_results=12)
+    assert result.error is None  # would AssertionError in fake_urlopen otherwise
+
+
+def test_query_question_is_url_quoted(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        # spaces and ampersands must be quoted in the URL
+        "GET http://daemon/search?q=hello+world+%26+more&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("hello world & more")
+    assert result.error is None
+```
+
+- [ ] **Step 2: Run the new tests; verify they fail with NotImplementedError**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v 2>&1 | tail -20`
+
+Expected: 6 new tests fail at the `NotImplementedError("Implemented in a later task")` line. Earlier auth tests still pass.
+
+- [ ] **Step 3: Implement `query()` happy path in the adapter**
+
+Replace the body of `query` in `sme/adapters/mempalace_daemon.py` with:
+
+```python
+    def query(
+        self,
+        question: str,
+        *,
+        n_results: int = 5,
+        kind: Optional[str] = None,
+        route: bool = False,  # accepted for CLI parity; daemon does its own
+        wing: Optional[str] = None,  # ignored; reserved for future expansion
+        room: Optional[str] = None,  # ignored; reserved for future expansion
+    ) -> QueryResult:
+        chosen_kind = kind or self.kind
+        params = urllib.parse.urlencode(
+            {"q": question, "limit": n_results, "kind": chosen_kind}
+        )
+        url = f"{self.api_url}/search?{params}"
+        body = self._http_get(url)
+        # body is a parsed dict here; errors are returned as QueryResult
+        if isinstance(body, QueryResult):
+            return body
+
+        results = body.get("results") or []
+        warnings = body.get("warnings") or []
+        total = body.get("total_before_filter")
+        available = body.get("available_in_scope")
+        retrieval_path = [
+            f"kind={chosen_kind}",
+            f"available_in_scope={available}",
+            f"total_before_filter={total}",
+        ]
+
+        if not results:
+            err = (
+                f"WARN: {'; '.join(warnings)}"
+                if warnings
+                else "NO_RESULTS"
+            )
+            return QueryResult(
+                answer="",
+                context_string="",
+                error=err,
+                retrieval_path=retrieval_path,
+            )
+
+        context_parts: list[str] = []
+        retrieved: list[Entity] = []
+        for i, hit in enumerate(results):
+            meta = hit.get("metadata") or {}
+            wing_name = meta.get("wing", "?")
+            room_name = meta.get("room", "?")
+            source_file = meta.get("source_file") or f"hit{i}"
+            source_label = Path(source_file).name or source_file
+            text = hit.get("text", "") or ""
+            context_parts.append(
+                f"[{i + 1}] [{wing_name}/{room_name}] {source_label}\n{text}"
+            )
+            retrieved.append(
+                Entity(
+                    id=f"drawer_hit:{i}",
+                    name=source_label,
+                    entity_type=f"drawer:{room_name}",
+                    properties={
+                        "_table": "mempalace_daemon_hit",
+                        "wing": wing_name,
+                        "room": room_name,
+                        "score": hit.get("score"),
+                        "source_file": source_file,
+                    },
+                )
+            )
+
+        context_string = "\n\n".join(context_parts)
+        warn_err = f"WARN: {'; '.join(warnings)}" if warnings else None
+        return QueryResult(
+            answer=context_string,
+            context_string=context_string,
+            retrieved_entities=retrieved,
+            retrieval_path=retrieval_path,
+            error=warn_err,
+        )
+
+    # --- HTTP plumbing ------------------------------------------------
+
+    def _http_get(self, url: str) -> Any:
+        """GET ``url`` with X-API-Key, return parsed JSON or a QueryResult
+        wrapping the error. Used by both query() and snapshot calls.
+        """
+        req = urllib.request.Request(
+            url, method="GET", headers={"X-API-Key": self.api_key}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.api_timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            try:
+                detail = e.read().decode("utf-8", errors="replace")[:200]
+            except Exception:
+                detail = str(e)
+            if e.code in (401, 403):
+                err = f"AUTH: invalid X-API-Key ({e.code})"
+            else:
+                err = f"HTTP {e.code}: {detail}"
+            return QueryResult(answer="", context_string="", error=err)
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            return QueryResult(
+                answer="", context_string="", error=f"CONNECTION: {e}"
+            )
+        except Exception as e:  # pragma: no cover
+            return QueryResult(
+                answer="", context_string="", error=f"INTERNAL: {e}"
+            )
+```
+
+- [ ] **Step 4: Re-run; verify the 6 new tests pass and earlier ones still pass**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v 2>&1 | tail -25`
+
+Expected: 11 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py
+git commit -m "$(cat <<'EOF'
+feat(adapters): MemPalaceDaemonAdapter.query happy path
+
+GET /search builds context_string in the same format as the existing
+MemPalaceAdapter so tiktoken counts stay comparable across adapters.
+retrieval_path captures kind + scope counts for downstream scoring.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `query()` error and warning paths
+
+**Files:**
+- Modify: `tests/test_mempalace_daemon_adapter.py`
+
+- [ ] **Step 1: Write failing tests for the error/warning paths**
+
+Append to `tests/test_mempalace_daemon_adapter.py`:
+
+```python
+# --- query() error paths --------------------------------------------
+
+
+def test_query_warnings_emit_soft_error_with_results(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    envelope = {
+        **_OK_ENVELOPE,
+        "warnings": ["vector search unavailable: Error finding id"],
+    }
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": envelope,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    # Soft signal: error set, but context_string still populated
+    assert result.error is not None
+    assert result.error.startswith("WARN:")
+    assert "vector search unavailable" in result.error
+    assert "first chunk text" in result.context_string
+
+
+def test_query_warnings_with_empty_results(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    envelope = {
+        "query": "memory",
+        "filters": {"wing": None, "room": None},
+        "total_before_filter": 0,
+        "available_in_scope": 150811,
+        "warnings": ["vector search unavailable: Error finding id"],
+        "results": [],
+    }
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": envelope,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("WARN:")
+    assert result.context_string == ""
+
+
+def test_query_no_results_returns_no_results(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    envelope = {**_OK_ENVELOPE, "results": [], "warnings": []}
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": envelope,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error == "NO_RESULTS"
+
+
+def test_query_auth_error_returns_AUTH(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    err = urllib.error.HTTPError(
+        "http://daemon/search", 401, "Unauthorized", {}, None
+    )
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": err,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("AUTH:")
+    assert "401" in result.error
+
+
+def test_query_5xx_returns_HTTP_error(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    err = urllib.error.HTTPError(
+        "http://daemon/search", 500, "Server Error", {}, None
+    )
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": err,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("HTTP 500")
+
+
+def test_query_connection_refused_returns_CONNECTION(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": (
+            urllib.error.URLError("Connection refused")
+        ),
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("CONNECTION:")
+
+
+def test_query_sends_x_api_key_header(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    captured = {}
+
+    def capture(req):
+        captured["headers"] = dict(req.header_items())
+        captured["url"] = req.full_url
+        return _OK_ENVELOPE  # factory will wrap into a _FakeResponse
+
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": capture,
+    })
+    a = _adapter(monkeypatch, tmp_path, api_key="my-secret")
+    a.query("memory")
+    # urllib normalises header names; check both casings
+    api_key_value = (
+        captured["headers"].get("X-api-key")
+        or captured["headers"].get("X-Api-Key")
+    )
+    assert api_key_value == "my-secret"
+```
+
+- [ ] **Step 2: Run; verify the 7 new tests fail or pass appropriately**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v 2>&1 | tail -30`
+
+Expected: depending on what was implemented in Task 3, some pass already (Task 3's `_http_get` already handles HTTPError/URLError). The header-capture and warnings-soft-error tests should pass too. **If anything is RED, fix the adapter or test until all 18 PASS.** No new code is expected here — Task 3's implementation should cover this — but write the tests anyway to lock in the contract.
+
+- [ ] **Step 3: Run again, confirm all green**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -v 2>&1 | tail -20`
+
+Expected: 18 PASSED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_mempalace_daemon_adapter.py
+git commit -m "$(cat <<'EOF'
+test(adapters): lock MemPalaceDaemonAdapter query error/warning contract
+
+Covers WARN-with-results soft signal, NO_RESULTS, AUTH, HTTP 5xx,
+connection failures, and X-API-Key header propagation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `get_graph_snapshot()` — `/graph` fast path
+
+**Why:** Implement the fast path first so the projection logic is exercised. The MCP fallback (Task 6) is a different code path producing the same projection.
+
+**Files:**
+- Modify: `sme/adapters/mempalace_daemon.py`
+- Modify: `tests/test_mempalace_daemon_adapter.py`
+
+- [ ] **Step 1: Write failing tests for the /graph fast path**
+
+Append to `tests/test_mempalace_daemon_adapter.py`:
+
+```python
+# --- get_graph_snapshot — /graph fast path --------------------------
+
+
+_GRAPH_RESPONSE = {
+    "wings": {
+        "memorypalace": 427,
+        "projects": 106183,
+        "umbra": 82,
+    },
+    "rooms": [
+        {"wing": "memorypalace", "rooms": {"architecture": 17, "diary": 235}},
+        {"wing": "projects", "rooms": {"architecture": 9, "general": 100}},
+        {"wing": "umbra", "rooms": {"diary": 12}},
+    ],
+    "tunnels": [
+        {"room": "architecture", "wings": ["memorypalace", "projects"]},
+        {"room": "diary", "wings": ["memorypalace", "umbra"]},
+    ],
+    "kg_entities": [
+        {"id": "e1", "name": "Multipass", "type": "concept", "properties": {}}
+    ],
+    "kg_triples": [
+        {
+            "subject": "e1",
+            "predicate": "described_by",
+            "object": "e1",
+            "valid_from": "2026-04-25",
+            "valid_to": None,
+            "confidence": 1.0,
+            "source_file": "README.md",
+        }
+    ],
+    "kg_stats": {"entities": 1, "triples": 1},
+}
+
+
+def test_snapshot_graph_endpoint_creates_wing_entities(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, edges = a.get_graph_snapshot()
+
+    wing_entities = [e for e in entities if e.entity_type == "wing"]
+    assert {e.name for e in wing_entities} == {"memorypalace", "projects", "umbra"}
+
+
+def test_snapshot_graph_endpoint_creates_room_entities_with_wings(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, _ = a.get_graph_snapshot()
+
+    rooms_by_name = {e.name: e for e in entities if e.id.startswith("room:")}
+    assert "architecture" in rooms_by_name
+    assert sorted(rooms_by_name["architecture"].properties["wings"]) == [
+        "memorypalace",
+        "projects",
+    ]
+    # 'general' is a catch-all and should be skipped, mirroring the
+    # existing direct adapter's filter.
+    assert "general" not in rooms_by_name
+
+
+def test_snapshot_graph_endpoint_member_of_edges(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    _, edges = a.get_graph_snapshot()
+
+    member_of = [e for e in edges if e.edge_type == "member_of"]
+    pairs = {(e.source_id, e.target_id) for e in member_of}
+    assert ("room:architecture", "wing:memorypalace") in pairs
+    assert ("room:architecture", "wing:projects") in pairs
+    assert ("room:diary", "wing:memorypalace") in pairs
+
+
+def test_snapshot_graph_endpoint_tunnel_edges(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    _, edges = a.get_graph_snapshot()
+    tunnels = [e for e in edges if e.edge_type == "tunnel"]
+    pairs = {
+        tuple(sorted([e.source_id, e.target_id]))
+        for e in tunnels
+    }
+    # architecture connects memorypalace<->projects
+    assert ("wing:memorypalace", "wing:projects") in pairs
+    # diary connects memorypalace<->umbra
+    assert ("wing:memorypalace", "wing:umbra") in pairs
+
+
+def test_snapshot_graph_endpoint_kg_entities_and_triples(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, edges = a.get_graph_snapshot()
+    kg_ents = [e for e in entities if e.id.startswith("kg:")]
+    assert len(kg_ents) == 1
+    assert kg_ents[0].name == "Multipass"
+
+    kg_edges = [e for e in edges if e.source_id.startswith("kg:")]
+    assert len(kg_edges) == 1
+    assert kg_edges[0].edge_type == "described_by"
+```
+
+- [ ] **Step 2: Run; verify the 5 snapshot tests fail with NotImplementedError**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v -k snapshot 2>&1 | tail -15`
+
+Expected: 5 FAILS at the `NotImplementedError("Implemented in a later task")` line.
+
+- [ ] **Step 3: Implement the `/graph` fast path + projection**
+
+In `sme/adapters/mempalace_daemon.py`, replace the body of `get_graph_snapshot` and add the projection helper:
+
+```python
+    def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
+        if self.prefer_graph_endpoint:
+            body = self._http_get(f"{self.api_url}/graph")
+            # _http_get returns QueryResult on error; treat 404 specifically
+            if isinstance(body, QueryResult):
+                if body.error and body.error.startswith("HTTP 404"):
+                    log.info(
+                        "/graph endpoint not present (404); falling back to MCP"
+                    )
+                else:
+                    log.warning(
+                        "/graph fetch failed: %s; falling back to MCP",
+                        body.error,
+                    )
+                return self._snapshot_via_mcp()
+            return self._project_graph(body)
+        return self._snapshot_via_mcp()
+
+    def _project_graph(self, body: dict) -> tuple[list[Entity], list[Edge]]:
+        """Turn the daemon's /graph response into (entities, edges).
+
+        Mirrors the wing/room/tunnel projection in
+        ``sme.adapters.mempalace.MemPalaceAdapter.get_graph_snapshot``,
+        minus drawer-level surface (impractical at 151K-drawer scale
+        through the HTTP API).
+        """
+        wings: dict[str, int] = body.get("wings") or {}
+        rooms_by_wing: list[dict] = body.get("rooms") or []
+        tunnels: list[dict] = body.get("tunnels") or []
+        kg_ents: list[dict] = body.get("kg_entities") or []
+        kg_trips: list[dict] = body.get("kg_triples") or []
+
+        entities: list[Entity] = []
+        edges: list[Edge] = []
+
+        # Wings
+        for wing in sorted(wings):
+            entities.append(
+                Entity(
+                    id=f"wing:{wing}",
+                    name=wing,
+                    entity_type="wing",
+                    properties={"_table": "wing", "drawer_count": wings[wing]},
+                )
+            )
+
+        # Rooms — collect wings-per-room across the per-wing lists
+        room_wings: dict[str, set[str]] = defaultdict(set)
+        room_count: dict[str, int] = defaultdict(int)
+        for entry in rooms_by_wing:
+            wing = entry.get("wing", "")
+            for room, n in (entry.get("rooms") or {}).items():
+                if not room or room == "general":
+                    continue
+                room_wings[room].add(wing)
+                room_count[room] += int(n or 0)
+
+        for room in sorted(room_wings):
+            wings_list = sorted(room_wings[room])
+            entities.append(
+                Entity(
+                    id=f"room:{room}",
+                    name=room,
+                    entity_type="room:untyped",
+                    properties={
+                        "_table": "room",
+                        "wings": wings_list,
+                        "drawer_count": room_count[room],
+                    },
+                )
+            )
+            for wing in wings_list:
+                edges.append(
+                    Edge(
+                        source_id=f"room:{room}",
+                        target_id=f"wing:{wing}",
+                        edge_type="member_of",
+                        properties={
+                            "_table": "structural",
+                            "drawer_count": room_count[room],
+                        },
+                    )
+                )
+
+        # Tunnels — wing<->wing for each shared room
+        for t in tunnels:
+            room = t.get("room", "")
+            t_wings = sorted(t.get("wings") or [])
+            for i, wa in enumerate(t_wings):
+                for wb in t_wings[i + 1:]:
+                    edges.append(
+                        Edge(
+                            source_id=f"wing:{wa}",
+                            target_id=f"wing:{wb}",
+                            edge_type="tunnel",
+                            properties={
+                                "_table": "structural",
+                                "via_room": room,
+                            },
+                        )
+                    )
+
+        # KG layer
+        for ke in kg_ents:
+            ent_id = ke.get("id")
+            if not ent_id:
+                continue
+            props = dict(ke.get("properties") or {})
+            props["_table"] = "kg_entity"
+            entities.append(
+                Entity(
+                    id=f"kg:{ent_id}",
+                    name=ke.get("name") or ent_id,
+                    entity_type=f"kg:{ke.get('type') or 'unknown'}",
+                    properties=props,
+                )
+            )
+        for tr in kg_trips:
+            subj, obj = tr.get("subject"), tr.get("object")
+            if not subj or not obj:
+                continue
+            edges.append(
+                Edge(
+                    source_id=f"kg:{subj}",
+                    target_id=f"kg:{obj}",
+                    edge_type=tr.get("predicate") or "kg_related",
+                    properties={
+                        "_table": "kg_triple",
+                        "_created_at": tr.get("valid_from"),
+                        "valid_to": tr.get("valid_to"),
+                        "confidence": tr.get("confidence"),
+                        "source_file": tr.get("source_file"),
+                    },
+                )
+            )
+
+        return entities, edges
+
+    def _snapshot_via_mcp(self) -> tuple[list[Entity], list[Edge]]:
+        """Stub — implemented in the next task."""
+        log.warning("MCP fallback path not yet implemented; returning empty")
+        return [], []
+```
+
+- [ ] **Step 4: Re-run; verify the 5 snapshot tests pass**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v -k snapshot 2>&1 | tail -20`
+
+Expected: 5 PASSED.
+
+- [ ] **Step 5: Run the full file; everything green**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -v 2>&1 | tail -25`
+
+Expected: 23 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py
+git commit -m "$(cat <<'EOF'
+feat(adapters): MemPalaceDaemonAdapter /graph fast-path snapshot
+
+GET /graph in one call; projects to wings, rooms, member_of, tunnel,
+and KG layers. Mirrors the existing direct adapter's projection minus
+drawer-level surface (impractical to fetch at scale over HTTP).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `get_graph_snapshot()` — MCP fallback path
+
+**Why:** Older daemons (pre-1.6.0) won't have `/graph`. The fallback walks `mempalace_list_wings` → `mempalace_list_rooms` per wing → `mempalace_list_tunnels`. This is the path that runs against the live daemon today (1.5.1).
+
+**Files:**
+- Modify: `sme/adapters/mempalace_daemon.py`
+- Modify: `tests/test_mempalace_daemon_adapter.py`
+
+- [ ] **Step 1: Write failing tests for MCP fallback**
+
+Append to `tests/test_mempalace_daemon_adapter.py`:
+
+```python
+# --- get_graph_snapshot — MCP fallback ------------------------------
+
+
+def _mcp_envelope(payload: dict) -> dict:
+    """Build an MCP tools/call response envelope wrapping a JSON payload."""
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": json.dumps(payload)}]},
+    }
+
+
+def test_snapshot_falls_back_to_mcp_on_404(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    import json as _json
+    fake_urlopen_factory({
+        "GET http://daemon/graph": (
+            urllib.error.HTTPError(
+                "http://daemon/graph", 404, "Not Found", {}, None
+            )
+        ),
+        "POST http://daemon/mcp": _mcp_request_router({
+            "mempalace_list_wings": {
+                "wings": {"memorypalace": 427, "umbra": 82}
+            },
+            "mempalace_list_tunnels": [
+                {"room": "diary", "wings": ["memorypalace", "umbra"]}
+            ],
+            "mempalace_list_rooms:memorypalace": {
+                "wing": "memorypalace",
+                "rooms": {"diary": 235, "architecture": 17},
+            },
+            "mempalace_list_rooms:umbra": {
+                "wing": "umbra",
+                "rooms": {"diary": 12},
+            },
+        }),
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, edges = a.get_graph_snapshot()
+    wing_names = {e.name for e in entities if e.entity_type == "wing"}
+    assert wing_names == {"memorypalace", "umbra"}
+    tunnels = [e for e in edges if e.edge_type == "tunnel"]
+    assert len(tunnels) == 1
+    pair = tuple(sorted([tunnels[0].source_id, tunnels[0].target_id]))
+    assert pair == ("wing:memorypalace", "wing:umbra")
+
+
+def test_snapshot_force_mcp_with_prefer_graph_false(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "POST http://daemon/mcp": _mcp_request_router({
+            "mempalace_list_wings": {"wings": {"only": 1}},
+            "mempalace_list_tunnels": [],
+            "mempalace_list_rooms:only": {"wing": "only", "rooms": {}},
+        }),
+    })
+    a = _adapter(
+        monkeypatch, tmp_path, prefer_graph_endpoint=False
+    )
+    entities, _ = a.get_graph_snapshot()
+    # Should NOT have hit /graph at all (no route registered for it)
+    wing_names = {e.name for e in entities if e.entity_type == "wing"}
+    assert wing_names == {"only"}
+
+
+def test_snapshot_partial_on_list_rooms_failure(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    """If list_rooms fails for one wing, the snapshot still returns
+    every other wing's data."""
+    fake_urlopen_factory({
+        "GET http://daemon/graph": urllib.error.HTTPError(
+            "http://daemon/graph", 404, "Not Found", {}, None
+        ),
+        "POST http://daemon/mcp": _mcp_request_router({
+            "mempalace_list_wings": {"wings": {"good": 1, "bad": 1}},
+            "mempalace_list_tunnels": [],
+            "mempalace_list_rooms:good": {"wing": "good", "rooms": {"r1": 5}},
+            # 'bad' wing's list_rooms raises
+            "mempalace_list_rooms:bad": urllib.error.HTTPError(
+                "http://daemon/mcp", 500, "tool error", {}, None
+            ),
+        }),
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, _ = a.get_graph_snapshot()
+    room_names = {e.name for e in entities if e.id.startswith("room:")}
+    assert "r1" in room_names  # the good wing's room is present
+```
+
+Then **also add the MCP request router helper** to the same test file (above
+the new tests is fine):
+
+```python
+def _mcp_request_router(routes_by_tool: dict):
+    """Returns a callable that fake_urlopen_factory can hand back as the
+    response for ``POST http://daemon/mcp``.
+
+    Inspects the request body to dispatch on (tool_name, arguments) and
+    returns the matching MCP envelope. Unknown tools raise AssertionError.
+    """
+    def _route(req, *, _routes=routes_by_tool):
+        body = req.data
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        rpc = json.loads(body)
+        params = rpc.get("params") or {}
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        # Per-wing list_rooms: key on tool:wing
+        if name == "mempalace_list_rooms":
+            key = f"mempalace_list_rooms:{args.get('wing')}"
+        else:
+            key = name
+        if key not in _routes:
+            raise AssertionError(f"unrouted MCP call: {key}")
+        result = _routes[key]
+        if isinstance(result, Exception):
+            raise result
+        return result
+    return _route
+```
+
+The factory in `tests/conftest.py` only handles plain values, not callables.
+Extend it now to support callables — update `tests/conftest.py`'s
+`fake_urlopen` body inside the `factory()` closure:
+
+```python
+        def fake_urlopen(req, timeout=None):
+            method = req.get_method()
+            url = req.full_url
+            key_full = f"{method} {url}"
+            if key_full in routes:
+                resp = routes[key_full]
+            else:
+                base = url.split("?", 1)[0]
+                key_base = f"{method} {base}"
+                if key_base in routes:
+                    resp = routes[key_base]
+                else:
+                    raise AssertionError(f"unexpected request: {key_full}")
+            # If the registered response is a callable, invoke it with the
+            # request — used for body-dispatching mocks (e.g. JSON-RPC).
+            if callable(resp) and not isinstance(resp, Exception):
+                resp = resp(req)
+            if isinstance(resp, Exception):
+                raise resp
+            if isinstance(resp, tuple):
+                status, body = resp
+                return _FakeResponse(body, status=status)
+            return _FakeResponse(resp)
+```
+
+- [ ] **Step 2: Run; verify the 3 new tests fail and the conftest still loads**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v -k mcp 2>&1 | tail -15`
+
+Expected: 3 FAILS — currently `_snapshot_via_mcp` returns empty.
+
+- [ ] **Step 3: Implement `_snapshot_via_mcp` + helpers**
+
+In `sme/adapters/mempalace_daemon.py`, replace the stub `_snapshot_via_mcp` with:
+
+```python
+    def _snapshot_via_mcp(self) -> tuple[list[Entity], list[Edge]]:
+        """Walk the four MCP read tools and project to (entities, edges).
+
+        Used when /graph is absent (older daemons) or when
+        ``prefer_graph_endpoint=False``.
+        """
+        wings_payload = self._mcp_call("mempalace_list_wings", {})
+        if wings_payload is None:
+            log.warning("list_wings failed; returning empty snapshot")
+            return [], []
+        wings: dict[str, int] = wings_payload.get("wings") or {}
+
+        # Per-wing list_rooms — sequential to match daemon-side rate limits;
+        # the daemon's MCP server runs each tool in its own asyncio task.
+        rooms_by_wing: list[dict] = []
+        for wing in sorted(wings):
+            rooms_payload = self._mcp_call(
+                "mempalace_list_rooms", {"wing": wing}
+            )
+            if rooms_payload is None:
+                log.warning("list_rooms(wing=%s) failed; skipping", wing)
+                continue
+            rooms_by_wing.append(rooms_payload)
+
+        tunnels_payload = self._mcp_call("mempalace_list_tunnels", {})
+        if tunnels_payload is None:
+            log.warning("list_tunnels failed; tunnels omitted from snapshot")
+            tunnels_payload = []
+        # The MCP tool returns a list directly — coerce to the /graph schema
+        # so _project_graph can consume it.
+        tunnels = (
+            tunnels_payload
+            if isinstance(tunnels_payload, list)
+            else tunnels_payload.get("tunnels", [])
+        )
+
+        synthesised = {
+            "wings": wings,
+            "rooms": rooms_by_wing,
+            "tunnels": tunnels,
+            "kg_entities": [],   # not reachable via MCP without arguments
+            "kg_triples": [],
+        }
+        return self._project_graph(synthesised)
+
+    def _mcp_call(self, tool: str, arguments: dict) -> Any:
+        """POST /mcp with a tools/call envelope. Returns the parsed
+        ``content[0].text`` JSON payload, or None on failure (logged).
+        """
+        rpc_body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.api_url}/mcp",
+            data=rpc_body,
+            method="POST",
+            headers={
+                "X-API-Key": self.api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.api_timeout) as resp:
+                envelope = json.loads(resp.read().decode("utf-8"))
+        except (
+            urllib.error.HTTPError,
+            urllib.error.URLError,
+            TimeoutError,
+            OSError,
+        ) as e:
+            log.warning("MCP %s failed: %s", tool, e)
+            return None
+        result = envelope.get("result") or {}
+        content = result.get("content") or []
+        if not content:
+            err = envelope.get("error")
+            if err:
+                log.warning("MCP %s returned error: %s", tool, err)
+            return None
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except Exception as e:  # pragma: no cover
+            log.warning("MCP %s returned non-JSON: %s (%s)", tool, text[:80], e)
+            return None
+```
+
+- [ ] **Step 4: Re-run; verify all 3 MCP tests pass**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v -k mcp 2>&1 | tail -15`
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Run full test file**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -v 2>&1 | tail -30`
+
+Expected: 26 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py tests/conftest.py
+git commit -m "$(cat <<'EOF'
+feat(adapters): MCP fallback path for MemPalaceDaemonAdapter snapshot
+
+When /graph is unavailable (older daemons or prefer_graph_endpoint=False),
+walk mempalace_list_wings, mempalace_list_rooms per wing, and
+mempalace_list_tunnels via POST /mcp. Per-wing failures degrade to a
+partial snapshot rather than aborting.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Ontology source + ingest_corpus error message
+
+**Why:** Cat 8 calls `get_ontology_source`. The daemon adapter should report the same readme-derived ontology as the existing direct adapter so cat8 results are comparable across the two.
+
+**Files:**
+- Modify: `sme/adapters/mempalace_daemon.py`
+- Modify: `tests/test_mempalace_daemon_adapter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_mempalace_daemon_adapter.py`:
+
+```python
+# --- ontology + ingest -----------------------------------------------
+
+
+def test_get_ontology_source_matches_existing_adapter(monkeypatch, tmp_path):
+    a = _adapter(monkeypatch, tmp_path)
+    ont = a.get_ontology_source()
+    assert ont["type"] == "readme"
+    declared = {entry["kind"] for entry in ont["schema"]}
+    assert "structural" in declared
+    assert "hall_vocabulary" in declared
+
+
+def test_ingest_corpus_raises_with_helpful_message(monkeypatch, tmp_path):
+    a = _adapter(monkeypatch, tmp_path)
+    with pytest.raises(NotImplementedError, match="diagnostic-only"):
+        a.ingest_corpus([])
+```
+
+- [ ] **Step 2: Run; verify failures (the ontology test should fail because the default returns the base class's empty dict)**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -x -v -k "ontology or ingest" 2>&1 | tail -10`
+
+Expected: 1 FAIL (ontology), 1 PASS (ingest).
+
+- [ ] **Step 3: Implement `get_ontology_source`**
+
+Add to `sme/adapters/mempalace_daemon.py` (just before the `close` method):
+
+```python
+    def get_ontology_source(self) -> dict:
+        """Return the same MemPalace readme-derived ontology as the
+        direct ChromaDB adapter, so Cat 8 results are comparable across
+        the two access paths. The schema *as documented* doesn't change
+        because the backend access path does."""
+        return {
+            "type": "readme",
+            "schema": [
+                {
+                    "kind": "structural",
+                    "entities": [
+                        "wing", "room", "hall", "tunnel", "closet", "drawer"
+                    ],
+                },
+                {
+                    "kind": "hall_vocabulary",
+                    "values": [
+                        "facts", "events", "discoveries",
+                        "preferences", "advice",
+                    ],
+                },
+            ],
+            "documentation": (
+                "MemPalace organizes memories into Wings, Rooms, Halls, "
+                "Tunnels, Closets, and Drawers. See the existing "
+                "MemPalaceAdapter docstring for the full vocabulary. "
+                "This adapter accesses the palace via palace-daemon's "
+                "HTTP API rather than direct ChromaDB; the documented "
+                "ontology is unchanged."
+            ),
+        }
+```
+
+- [ ] **Step 4: Re-run**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -v 2>&1 | tail -15`
+
+Expected: 28 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py
+git commit -m "$(cat <<'EOF'
+feat(adapters): MemPalaceDaemonAdapter ontology + ingest error message
+
+Returns the same readme-typed ontology as the existing MemPalaceAdapter so
+Cat 8 readings are comparable across the direct-ChromaDB and HTTP paths.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: CLI plumbing — `_load_adapter` branch + flags
+
+**Why:** Without CLI exposure, the adapter is unreachable via `sme-eval`. This task wires it into the existing `_load_adapter`, the shared arg helpers, and the `retrieve` subcommand specifically.
+
+**Files:**
+- Modify: `sme/cli.py`
+
+- [ ] **Step 1: Read the relevant CLI sections to confirm line numbers haven't drifted**
+
+Run: `grep -n "_load_adapter\|_add_db_or_api_args\|cmd_retrieve" sme/cli.py`
+
+Expected output should include:
+- `def _load_adapter(name: str, **kwargs)` near line 25
+- `def _add_db_or_api_args(parser` near line 464
+- `def cmd_retrieve(args` near line 721
+
+If these have drifted, update the offsets in the steps below to match.
+
+- [ ] **Step 2: Add the `mempalace-daemon` branch to `_load_adapter`**
+
+In `sme/cli.py`, find the block that handles `mempalace`:
+
+```python
+    if name == "mempalace":
+        from sme.adapters.mempalace import MemPalaceAdapter
+        ...
+        return MemPalaceAdapter(**kwargs)
+```
+
+**Insert immediately before that block:**
+
+```python
+    if name in ("mempalace-daemon", "mempalace_daemon"):
+        from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+
+        # Drop kwargs the daemon adapter doesn't understand
+        for k in (
+            "include_node_tables",
+            "include_edge_tables",
+            "auto_discover",
+            "kg_path",
+            "collection_name",
+            "default_query_mode",
+            "db_path",
+            "buffer_pool_size",
+        ):
+            kwargs.pop(k, None)
+        return MemPalaceDaemonAdapter(**kwargs)
+```
+
+- [ ] **Step 3: Add `--api-key` and `--kind` to `_add_db_or_api_args`**
+
+In `sme/cli.py`, find `_add_db_or_api_args` (~line 464). Append at the end of the function:
+
+```python
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        metavar="KEY",
+        help="(mempalace-daemon) X-API-Key for the palace-daemon. "
+        "Defaults to PALACE_API_KEY in ~/.config/palace-daemon/env, "
+        "then to the process env var of the same name.",
+    )
+    parser.add_argument(
+        "--kind",
+        default=None,
+        metavar="KIND",
+        help="(mempalace-daemon) /search kind filter. Defaults to "
+        "'content' (excludes Stop-hook auto-save checkpoints). Use "
+        "'all' to disable, or 'checkpoint' for snapshot-only lookups.",
+    )
+```
+
+- [ ] **Step 4: Thread `--api-key` and `--kind` through `_load_adapter_from_args`**
+
+In `sme/cli.py`, find `_load_adapter_from_args` (~line 437). Update the for-loop that maps argparse attrs to adapter kwargs:
+
+```python
+    for attr, key in (
+        ("auto_discover", "auto_discover"),
+        ("node_tables", "include_node_tables"),
+        ("edge_tables", "include_edge_tables"),
+        ("kg_path", "kg_path"),
+        ("collection_name", "collection_name"),
+        ("api_key", "api_key"),    # NEW
+        ("kind", "kind"),          # NEW
+    ):
+        val = getattr(args, attr, None)
+        if val:
+            adapter_kwargs[key] = val
+```
+
+- [ ] **Step 5: Add `--api-url`, `--api-key`, `--kind` to the `retrieve` subparser**
+
+In `sme/cli.py`, find the `retrieve` subparser block (~line 995). Locate this snippet:
+
+```python
+    ret.add_argument(
+        "--api-url",
+        metavar="URL",
+        help="(ladybugdb) HTTP base URL for API-mode queries (e.g. "
+        ...
+    )
+```
+
+It already exists — but mention of mempalace-daemon is missing. **Replace** the
+help text:
+
+```python
+    ret.add_argument(
+        "--api-url",
+        metavar="URL",
+        help="(ladybugdb, mempalace-daemon) HTTP base URL for API-mode "
+        "queries (e.g. http://disks.jphe.in:8085).",
+    )
+```
+
+Then **add immediately after** that block:
+
+```python
+    ret.add_argument(
+        "--api-key",
+        metavar="KEY",
+        help="(mempalace-daemon) X-API-Key. Defaults to PALACE_API_KEY in "
+        "~/.config/palace-daemon/env, then process env.",
+    )
+    ret.add_argument(
+        "--kind",
+        metavar="KIND",
+        help="(mempalace-daemon) /search kind filter. Default 'content'.",
+    )
+```
+
+- [ ] **Step 6: Thread the new flags through `cmd_retrieve`'s adapter construction**
+
+In `sme/cli.py`, find `cmd_retrieve` (~line 721). Locate the kwargs-packing block (~line 746):
+
+```python
+    adapter_kwargs: dict[str, Any] = {
+        "db_path": args.db,
+        "read_only": True,
+    }
+    if args.collection_name:
+        adapter_kwargs["collection_name"] = args.collection_name
+    if getattr(args, "api_url", None):
+        adapter_kwargs["api_url"] = args.api_url
+    if getattr(args, "query_mode", None):
+        adapter_kwargs["default_query_mode"] = args.query_mode
+```
+
+**Append before the `adapter = _load_adapter(...)` line:**
+
+```python
+    if getattr(args, "api_key", None):
+        adapter_kwargs["api_key"] = args.api_key
+    if getattr(args, "kind", None):
+        adapter_kwargs["kind"] = args.kind
+```
+
+- [ ] **Step 7: Run a CLI smoke import sanity check**
+
+Run: `python3 -c "from sme.cli import main; print('ok')"`
+
+Expected: `ok`. (No SyntaxError, no ImportError.)
+
+- [ ] **Step 8: Run a `--help` smoke**
+
+Run: `python3 -m sme.cli retrieve --help 2>&1 | grep -E "api-url|api-key|kind"`
+
+Expected: lines for `--api-url`, `--api-key`, `--kind` all present.
+
+- [ ] **Step 9: Run the full unit test suite to confirm nothing regressed**
+
+Run: `pytest tests/ -v 2>&1 | tail -10`
+
+Expected: all green; the new adapter tests + the existing Cat 4 / Cat 5 / gap tests all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add sme/cli.py
+git commit -m "$(cat <<'EOF'
+feat(cli): wire mempalace-daemon adapter, --api-key, --kind
+
+Adds the mempalace-daemon branch to _load_adapter and threads
+--api-key / --kind through _load_adapter_from_args and the retrieve
+subparser.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Live-daemon integration smoke test (gated)
+
+**Files:**
+- Create: `tests/test_mempalace_daemon_integration.py`
+
+- [ ] **Step 1: Write the gated integration test**
+
+Create `tests/test_mempalace_daemon_integration.py`:
+
+```python
+"""Live-daemon smoke tests for MemPalaceDaemonAdapter.
+
+Skipped automatically when PALACE_DAEMON_URL is not set in the
+environment, so CI without a daemon stays green. Run locally with:
+
+    PALACE_DAEMON_URL=http://disks.jphe.in:8085 \
+    PALACE_API_KEY=$(grep ^PALACE_API_KEY ~/.config/palace-daemon/env | cut -d= -f2) \
+    pytest tests/test_mempalace_daemon_integration.py -v
+
+The tests are read-only: query() and get_graph_snapshot() only.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from sme.adapters.base import QueryResult
+from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("PALACE_DAEMON_URL"),
+    reason="needs a running palace-daemon; set PALACE_DAEMON_URL to enable",
+)
+
+
+@pytest.fixture
+def adapter():
+    a = MemPalaceDaemonAdapter()
+    yield a
+    a.close()
+
+
+def test_query_returns_query_result(adapter):
+    r = adapter.query("hello", n_results=2)
+    assert isinstance(r, QueryResult)
+    # Either we got results, or we got a soft-warn / NO_RESULTS — never an
+    # uncaught exception.
+
+
+def test_snapshot_returns_at_least_one_wing(adapter):
+    entities, _ = adapter.get_graph_snapshot()
+    wing_names = {e.name for e in entities if e.entity_type == "wing"}
+    # Live palace has 30+ wings on JP's install; even a fresh palace has >=1.
+    assert len(wing_names) >= 1
+
+
+def test_kind_default_excludes_more_than_kind_all(adapter):
+    """Cross-check the README's claim: kind='content' filters strictly
+    less than kind='all'. If the live palace has any auto-save
+    checkpoints, this assertion holds; on a fresh palace it might be
+    equal — assert >= rather than > to avoid flakes."""
+    r_all = adapter.query("the", n_results=5, kind="all")
+    r_content = adapter.query("the", n_results=5, kind="content")
+    # We can't compare result counts directly because limit caps both;
+    # use total_before_filter from retrieval_path.
+    def total_before(rp):
+        for s in rp:
+            if s.startswith("total_before_filter="):
+                return int(s.split("=", 1)[1])
+        return -1
+    assert total_before(r_all.retrieval_path) >= total_before(
+        r_content.retrieval_path
+    )
+```
+
+- [ ] **Step 2: Confirm the gate works (test SKIPS without the env var)**
+
+Run: `pytest tests/test_mempalace_daemon_integration.py -v 2>&1 | tail -10`
+
+Expected: tests SKIPPED (the SKIPIF triggers because `PALACE_DAEMON_URL` isn't set in the test process by default).
+
+- [ ] **Step 3: Run with the live daemon**
+
+Run:
+
+```bash
+set -a; source ~/.config/palace-daemon/env; set +a
+pytest tests/test_mempalace_daemon_integration.py -v
+```
+
+Expected: 3 PASSED. If `query("hello")` lands on the buggy `kind=content` vector path, `r.error` may start with `WARN:` — that's a pass for the contract test (we're checking we get a `QueryResult`, not asserting clean retrieval).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_mempalace_daemon_integration.py
+git commit -m "$(cat <<'EOF'
+test(adapters): live-daemon smoke for MemPalaceDaemonAdapter (gated)
+
+Skipped when PALACE_DAEMON_URL is unset so CI without a daemon stays
+green. Asserts query() returns a QueryResult, snapshot returns >=1
+wing, and kind=all >= kind=content for total_before_filter (validates
+the README's filter claim).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: End-to-end CLI smoke against the live daemon
+
+**Why:** Unit tests cover the adapter; integration tests cover the live HTTP. This task catches CLI-wiring bugs that only show up when `sme-eval retrieve` actually invokes everything together.
+
+**Files:**
+- Create: `tests/fixtures/tiny_questions.yaml`
+
+- [ ] **Step 1: Create a tiny corpus YAML for the smoke**
+
+Create `tests/fixtures/tiny_questions.yaml`:
+
+```yaml
+version: "smoke-2026-04-25"
+questions:
+  - id: q1
+    text: "what is the structural memory evaluation framework"
+    expected_sources: []
+    min_hops: 0
+  - id: q2
+    text: "how does mempalace organize memories"
+    expected_sources: []
+    min_hops: 0
+```
+
+- [ ] **Step 2: Run the smoke against the live daemon**
+
+Run:
+
+```bash
+set -a; source ~/.config/palace-daemon/env; set +a
+sme-eval retrieve \
+    --adapter mempalace-daemon \
+    --questions tests/fixtures/tiny_questions.yaml \
+    --n-results 3 \
+    --json /tmp/mempalace-daemon-smoke.json
+```
+
+Expected:
+- Two question results printed.
+- No Python tracebacks.
+- A JSON file written to `/tmp/mempalace-daemon-smoke.json`.
+- `cat /tmp/mempalace-daemon-smoke.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['adapter'], len(d['questions']), d['summary']['mean_recall'])"` prints `mempalace-daemon 2 <some_float>`.
+
+If this surfaces `WARN:` errors for some questions, that's expected on the
+current daemon (the `kind=content` vector-path bug). The smoke is checking
+that the CLI plumbing works end-to-end, not that retrieval is clean.
+
+- [ ] **Step 3: Commit the fixture**
+
+```bash
+git add tests/fixtures/tiny_questions.yaml
+git commit -m "$(cat <<'EOF'
+test(fixtures): tiny corpus for mempalace-daemon CLI smoke
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: README — update the fork-roadmap section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Locate the section to replace**
+
+Run: `grep -n "Planned: \`mempalace-daemon\` adapter\|Why the existing adapter still has a use" README.md`
+
+Expected: two line numbers — these bracket the section to rewrite.
+
+- [ ] **Step 2: Replace the "Planned" subsection with shipped status**
+
+In `README.md`, find the heading `### Planned: \`mempalace-daemon\` adapter` and replace **everything from that heading up to and including the closing of "Why the existing adapter still has a use"** with:
+
+```markdown
+### Shipped: `mempalace-daemon` adapter
+
+`sme/adapters/mempalace_daemon.py` talks to a running
+[`palace-daemon`](https://github.com/jphein/palace-daemon) over HTTP.
+No filesystem access, no ChromaDB import, no shared-process constraint
+with the daemon. Use this adapter when MemPalace is fronted by the
+daemon (the daemon is the single writer to the palace) — the existing
+`mempalace` adapter is still correct for single-process upstream
+installs without the daemon.
+
+**Wired endpoints:**
+
+- `query()` → `GET /search?q=…&kind=…&limit=…` with `X-API-Key`. Default
+  `kind="content"` excludes Stop-hook auto-save checkpoints; pass
+  `--kind all` to disable. Daemon-side `warnings` (e.g. broken HNSW
+  index) are surfaced into `QueryResult.error` as `WARN: …` so Cat 9
+  scoring can distinguish flagged retrieval from clean retrieval.
+- `get_graph_snapshot()` → tries `GET /graph` first (palace-daemon
+  ≥1.6.0); on 404, falls back to walking `mempalace_list_wings`,
+  `mempalace_list_rooms` per wing, and `mempalace_list_tunnels` via
+  `POST /mcp`.
+
+**Auth resolution:** explicit `--api-url` / `--api-key` flags →
+`~/.config/palace-daemon/env` (`PALACE_DAEMON_URL`, `PALACE_API_KEY`)
+→ process environment.
+
+**Invocation:**
+
+```bash
+sme-eval retrieve --adapter mempalace-daemon \
+    --api-url http://your-daemon:8085 \
+    --questions corpus.yaml \
+    --kind content \
+    --json out.json
+```
+
+If `--api-url` is omitted, the env file is read automatically.
+
+#### Why the existing adapter still has a use
+
+For users running upstream MemPalace without palace-daemon (the default
+install pattern), the existing `mempalace` adapter is correct — single
+process, no daemon, direct ChromaDB access is fine. The daemon adapter
+is *additive*, for users who've adopted palace-daemon's single-writer
+architecture.
+```
+
+- [ ] **Step 3: Sanity-check the README still renders cleanly**
+
+Run: `python3 -c "import pathlib; print('len ok' if len(pathlib.Path('README.md').read_text()) > 1000 else 'EMPTY')"`
+
+Expected: `len ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs(readme): mempalace-daemon adapter — planned → shipped
+
+Replaces the fork-roadmap planning subsection with the wired-endpoint
+description, auth resolution rules, and invocation example.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Final sweep
+
+- [ ] **Step 1: Full test suite**
+
+Run: `pytest tests/ -v 2>&1 | tail -15`
+
+Expected: every test green; integration tests SKIPPED unless the env var is set.
+
+- [ ] **Step 2: Lint pass**
+
+Run: `ruff check sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py`
+
+Expected: clean. Fix any issues inline; if there are any, recommit:
+
+```bash
+git add sme/adapters/mempalace_daemon.py tests/test_mempalace_daemon_adapter.py
+git commit -m "$(cat <<'EOF'
+chore: ruff fixes for mempalace_daemon adapter
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm git state is clean**
+
+Run: `git status && git log --oneline -15`
+
+Expected: working tree clean; ~7-9 commits ahead of `7b3bf4a` (the spec commit).
+
+- [ ] **Step 4: Speak completion**
+
+Run:
+
+```bash
+notify-send "sme-eval" "mempalace-daemon adapter shipped"
+```
+
+(If `mcp__speech-to-cli__speak` is available in the executing context, prefer:
+`speak "mempalace-daemon adapter shipped" --voice en-US-Davis:DragonHDLatestNeural --quality hd`)
+
+---
+
+## Coverage check (cross-reference against the spec)
+
+| Spec section | Implemented in task |
+|---|---|
+| §A constructor signature | Task 2 |
+| §A auth resolution rules | Task 2 |
+| §A `query()` happy path | Task 3 |
+| §A `query()` warnings → soft error | Task 4 |
+| §A `query()` error envelope | Task 3 + Task 4 |
+| §A `get_graph_snapshot` /graph fast path | Task 5 |
+| §A `get_graph_snapshot` MCP fallback | Task 6 |
+| §A `get_ontology_source` | Task 7 |
+| §A `ingest_corpus` raises | Task 7 |
+| §B `/graph` endpoint on daemon | **OUT OF SCOPE — JP's daemon work** |
+| §C `_load_adapter` branch | Task 8 |
+| §C `--api-key`, `--kind` flags | Task 8 |
+| §C make `--db` optional for retrieve | Already optional in CLI; verified Task 8 step 8 |
+| Error-handling table | Tasks 3, 4, 6 |
+| Unit testing | Tasks 2, 3, 4, 5, 6, 7 |
+| Integration smoke (gated) | Task 9 |
+| CLI smoke | Task 10 |
+| README update | Task 11 |

--- a/docs/superpowers/plans/2026-04-26-familiar-adapter.md
+++ b/docs/superpowers/plans/2026-04-26-familiar-adapter.md
@@ -1,0 +1,1562 @@
+# FamiliarAdapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fifth `SMEAdapter` to multipass — `FamiliarAdapter` — that talks to a running familiar.realm.watch v0.2.0+ instance via HTTP, so SME can score the v0.2 retrieval pipeline (rerank/decay/compress/grounding) against curated test corpora.
+
+**Architecture:** HTTP wrapper around `POST /api/familiar/eval` (which already returns SME-shape) and `GET /api/familiar/graph` (which proxies palace-daemon's `/graph`). Defaults to `mock=true` for Cat 1 determinism. Graph-snapshot mapping is shared with `MemPalaceDaemonAdapter` via a small extracted helper module.
+
+**Tech Stack:** Python 3.12+, stdlib `urllib.request` for HTTP (matches `MemPalaceDaemonAdapter` convention — no httpx), pytest, pytest's `monkeypatch` + the existing `fake_urlopen_factory` fixture in `tests/conftest.py`.
+
+---
+
+## File Structure
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `sme/adapters/_graph_mapping.py` | Shared `/graph` JSON to `(Entity, Edge)` mapping helpers, extracted from `mempalace_daemon.py` |
+| Create | `sme/adapters/familiar.py` | The `FamiliarAdapter` class (~400 lines) |
+| Create | `tests/test_familiar_adapter.py` | Unit tests with mocked HTTP via `fake_urlopen_factory` |
+| Create | `tests/test_familiar_live.py` | Gated live smoke test (skipped unless `FAMILIAR_BASE_URL` env set) |
+| Modify | `sme/adapters/mempalace_daemon.py` | Replace inlined `_project_graph` with shared module import |
+| Modify | `sme/cli.py` | Wire `--adapter familiar` plus `--mock`/`--no-mock` flags |
+| Modify | `README.md` | Adapter table row + Quickstart subsection for familiar |
+| Modify | `docs/ideas.md` | Note that familiar's per-question records prepare for future Cat 9 |
+
+---
+
+## Task 1: Extract `/graph` mapping into shared module
+
+**Files:**
+- Create: `sme/adapters/_graph_mapping.py`
+- Modify: `sme/adapters/mempalace_daemon.py:244-364` (replace `_project_graph`)
+- Test: `tests/test_mempalace_daemon_adapter.py` (re-run unchanged, must still pass)
+
+- [ ] **Step 1: Read the existing `_project_graph` to understand the contract**
+
+Run: `sed -n '244,364p' sme/adapters/mempalace_daemon.py`
+Expected: a method that takes a dict (the `/graph` body) and returns `tuple[list[Entity], list[Edge]]`.
+
+- [ ] **Step 2: Create the shared module**
+
+Create `sme/adapters/_graph_mapping.py`:
+
+```python
+"""Shared /graph payload to (Entity, Edge) mapping.
+
+palace-daemon's GET /graph returns a single payload shape (wings,
+rooms, tunnels, kg_entities, kg_triples, kg_stats). Both
+MemPalaceDaemonAdapter and FamiliarAdapter consume this shape.
+Familiar's GET /api/familiar/graph proxies the daemon's response
+unchanged (with a 5-minute cache), so both can use the same mapping.
+
+Extracted from MemPalaceDaemonAdapter._project_graph 2026-04-26.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from sme.adapters.base import Edge, Entity
+
+
+def project_graph(body: dict[str, Any]) -> tuple[list[Entity], list[Edge]]:
+    """Map a /graph JSON body to lists of Entity and Edge.
+
+    Mirrors what MemPalaceAdapter.get_graph_snapshot produces from
+    direct ChromaDB access, at the coarser-than-drawer granularity
+    the daemon's /graph endpoint exposes.
+    """
+    wings: dict[str, int] = body.get("wings") or {}
+    rooms_per_wing: list[dict] = body.get("rooms") or []
+    tunnels: list[dict] = body.get("tunnels") or []
+    kg_ents: list[dict] = body.get("kg_entities") or []
+    kg_triples: list[dict] = body.get("kg_triples") or []
+
+    entities: list[Entity] = []
+    edges: list[Edge] = []
+
+    # Wings
+    for wing in sorted(wings):
+        entities.append(
+            Entity(
+                id=f"wing:{wing}",
+                name=wing,
+                entity_type="wing",
+                properties={"_table": "wing", "drawer_count": wings[wing]},
+            )
+        )
+
+    # Rooms — collect wings-per-room across the per-wing lists
+    room_wings: dict[str, set[str]] = defaultdict(set)
+    for entry in rooms_per_wing:
+        wing = entry.get("wing")
+        if not wing:
+            continue
+        for room in (entry.get("rooms") or {}):
+            room_wings[room].add(wing)
+    for room in sorted(room_wings):
+        wings_list = sorted(room_wings[room])
+        entities.append(
+            Entity(
+                id=f"room:{room}",
+                name=room,
+                entity_type="room",
+                properties={
+                    "_table": "room",
+                    "wings": wings_list,
+                },
+            )
+        )
+        for wing in wings_list:
+            edges.append(
+                Edge(
+                    source_id=f"wing:{wing}",
+                    target_id=f"room:{room}",
+                    edge_type="contains_room",
+                )
+            )
+
+    # Tunnels — cross-wing topic edges
+    for tunnel in tunnels:
+        room = tunnel.get("room")
+        wings_in = tunnel.get("wings") or []
+        if not room or len(wings_in) < 2:
+            continue
+        # tunnel is a clique among the wings via the shared room
+        for i, wa in enumerate(wings_in):
+            for wb in wings_in[i + 1:]:
+                edges.append(
+                    Edge(
+                        source_id=f"wing:{wa}",
+                        target_id=f"wing:{wb}",
+                        edge_type="topic_tunnel",
+                        properties={"shared_room": room},
+                    )
+                )
+
+    # KG entities
+    for ent in kg_ents:
+        eid = ent.get("id")
+        if not eid:
+            continue
+        entities.append(
+            Entity(
+                id=f"kg:{eid}",
+                name=ent.get("name") or eid,
+                entity_type=ent.get("type") or "kg_entity",
+                properties={
+                    "_table": "kg_entity",
+                    **(ent.get("properties") or {}),
+                },
+            )
+        )
+
+    # KG triples
+    for triple in kg_triples:
+        s = triple.get("subject")
+        o = triple.get("object")
+        p = triple.get("predicate")
+        if not (s and o and p):
+            continue
+        props: dict[str, Any] = {}
+        for key in ("valid_from", "valid_to", "confidence", "source_file"):
+            if triple.get(key) is not None:
+                props[key] = triple[key]
+        edges.append(
+            Edge(
+                source_id=f"kg:{s}",
+                target_id=f"kg:{o}",
+                edge_type=p,
+                properties=props,
+            )
+        )
+
+    return entities, edges
+```
+
+- [ ] **Step 3: Update `mempalace_daemon.py` to use the shared module**
+
+In `sme/adapters/mempalace_daemon.py`:
+- Add import at the top: `from sme.adapters._graph_mapping import project_graph`
+- Replace the body of `_project_graph(self, body: dict)` with:
+
+```python
+def _project_graph(self, body: dict) -> tuple[list[Entity], list[Edge]]:
+    """Map /graph payload to (Entity, Edge). Delegates to shared module."""
+    return project_graph(body)
+```
+
+- [ ] **Step 4: Run mempalace_daemon tests to confirm refactor is non-breaking**
+
+Run: `pytest tests/test_mempalace_daemon_adapter.py -v`
+Expected: all pre-existing tests pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/_graph_mapping.py sme/adapters/mempalace_daemon.py
+git commit -m "refactor(adapters): extract /graph payload mapping into shared module
+
+Both MemPalaceDaemonAdapter and the upcoming FamiliarAdapter consume
+the same /graph payload shape (familiar's /api/familiar/graph is a
+verbatim proxy of palace-daemon's /graph). Extract project_graph into
+sme/adapters/_graph_mapping.py so both adapters share the implementation
+and stay in lock-step if the upstream shape evolves.
+
+Existing mempalace_daemon tests pass unchanged."
+```
+
+---
+
+## Task 2: Scaffold `FamiliarAdapter` class skeleton
+
+**Files:**
+- Create: `sme/adapters/familiar.py`
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing test for instantiation defaults**
+
+Create `tests/test_familiar_adapter.py`:
+
+```python
+"""Unit tests for FamiliarAdapter."""
+
+from __future__ import annotations
+
+import json
+import pytest
+
+from sme.adapters.familiar import FamiliarAdapter
+
+
+def test_default_construction():
+    adapter = FamiliarAdapter()
+    assert adapter.base_url == "http://familiar:8080"
+    assert adapter.timeout_s == 30.0
+    assert adapter.mock_inference is True
+
+
+def test_explicit_construction():
+    adapter = FamiliarAdapter(
+        base_url="https://familiar.jphe.in",
+        timeout_s=10.0,
+        mock_inference=False,
+    )
+    assert adapter.base_url == "https://familiar.jphe.in"
+    assert adapter.timeout_s == 10.0
+    assert adapter.mock_inference is False
+
+
+def test_base_url_trailing_slash_stripped():
+    adapter = FamiliarAdapter(base_url="https://familiar.jphe.in/")
+    assert adapter.base_url == "https://familiar.jphe.in"
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pytest tests/test_familiar_adapter.py::test_default_construction -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'sme.adapters.familiar'`.
+
+- [ ] **Step 3: Create the adapter skeleton**
+
+Create `sme/adapters/familiar.py`:
+
+```python
+"""FamiliarAdapter — SME adapter for familiar.realm.watch v0.2.0+.
+
+Familiar wraps palace-daemon with a v0.2 retrieval pipeline (rerank,
+temporal decay, extractive compression, grounding directives). This
+adapter measures familiar's full pipeline; the sibling
+MemPalaceDaemonAdapter measures palace alone. Comparing their SME
+scores quantifies what familiar's v0.2 contributes.
+
+POST /api/familiar/eval already returns SME-QueryResult shape natively
+(familiar's chunk-C of v0.2 was designed against this contract), so the
+adapter is mostly deserialization with error/warning translation rules.
+GET /api/familiar/graph proxies palace-daemon's /graph; reuse the
+shared mapping module.
+
+Defaults to mock_inference=True so Cat 1 substring scoring stays
+deterministic — no LLM in the loop. Inference-mode runs are reserved
+for a future Cat 9 pass.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from sme.adapters.base import Edge, Entity, QueryResult, SMEAdapter
+
+
+DEFAULT_BASE_URL = "http://familiar:8080"
+DEFAULT_TIMEOUT_S = 30.0
+
+
+class FamiliarAdapter(SMEAdapter):
+    """Adapter for a running familiar.realm.watch v0.2.0+ instance."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        mock_inference: bool = True,
+        opener: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_s = timeout_s
+        self.mock_inference = mock_inference
+        # `opener` is injected by tests via fake_urlopen_factory; production
+        # code uses urllib.request.urlopen directly.
+        self._opener = opener
+
+    # --- Required SMEAdapter methods (filled in by later tasks) ---
+
+    def ingest_corpus(self, corpus: list[dict]) -> dict:
+        raise NotImplementedError("Task 3")
+
+    def query(self, question: str) -> QueryResult:
+        raise NotImplementedError("Task 4-7")
+
+    def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
+        raise NotImplementedError("Task 8")
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): scaffold FamiliarAdapter skeleton
+
+Class structure + constructor + base URL trim. Methods stub out to
+NotImplementedError; subsequent tasks fill them in. Mirrors the
+MemPalaceDaemonAdapter constructor shape (base_url, timeout_s, opener
+for test injection)."
+```
+
+---
+
+## Task 3: Implement `ingest_corpus` as no-op stub
+
+**Files:**
+- Modify: `sme/adapters/familiar.py`
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+def test_ingest_corpus_is_noop():
+    adapter = FamiliarAdapter()
+    result = adapter.ingest_corpus([{"id": "doc-1", "text": "anything"}])
+    assert result["entities_created"] == 0
+    assert result["edges_created"] == 0
+    assert result["errors"] == []
+    assert any("diagnostic-only" in w.lower() or "no-op" in w.lower()
+               for w in result["warnings"])
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pytest tests/test_familiar_adapter.py::test_ingest_corpus_is_noop -v`
+Expected: FAIL with `NotImplementedError: Task 3`.
+
+- [ ] **Step 3: Implement the stub**
+
+In `sme/adapters/familiar.py`, replace the `ingest_corpus` body:
+
+```python
+def ingest_corpus(self, corpus: list[dict]) -> dict:
+    """No-op stub. Familiar reads palace data it didn't author;
+    ingestion happens upstream via `mempalace mine`."""
+    return {
+        "entities_created": 0,
+        "edges_created": 0,
+        "errors": [],
+        "warnings": [
+            "FamiliarAdapter is diagnostic-only (Mode B). Familiar reads "
+            "palace data it didn't author; ingestion happens upstream via "
+            "`mempalace mine`. ingest_corpus is a no-op."
+        ],
+    }
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): FamiliarAdapter.ingest_corpus no-op stub
+
+Mode B (diagnostic-only) — same pattern as MemPalaceDaemonAdapter."
+```
+
+---
+
+## Task 4: Implement `query()` happy path (mock=true success)
+
+**Files:**
+- Modify: `sme/adapters/familiar.py` (add `_post_json` helper + `query`)
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing test using `fake_urlopen_factory`**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+def test_query_happy_path(fake_urlopen_factory):
+    """Mocked POST /api/familiar/eval returns SME-shape JSON.
+    Adapter deserializes into a QueryResult with all fields populated."""
+    response_body = {
+        "answer": "(mock=true: inference skipped)",
+        "context_string": "── Palace context (1 drawer) ──\n[drawer_abc · wing=projects · room=technical]\nUser enjoys hiking.",
+        "retrieved_entities": [
+            {
+                "id": "drawer_abc",
+                "type": "drawer",
+                "wing": "projects",
+                "room": "technical",
+                "topic": "hobbies",
+                "content_snippet": "User enjoys hiking.",
+                "cosine": 0.81,
+                "bm25": 0.42,
+                "matched_via": "drawer",
+                "provenance": {"kind": "observed"},
+            }
+        ],
+        "retrieved_edges": [],
+        "error": None,
+        "warnings": [],
+        "available_in_scope": 151478,
+    }
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval": (200, response_body),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+
+    result = adapter.query("What are my hobbies?")
+
+    assert result.error is None
+    assert result.answer.startswith("(mock=true")
+    assert "User enjoys hiking" in result.context_string
+    assert len(result.retrieved_entities) == 1
+    e = result.retrieved_entities[0]
+    assert e.id == "drawer_abc"
+    assert e.entity_type == "drawer"
+    assert e.properties["wing"] == "projects"
+    assert e.properties["cosine"] == 0.81
+    assert result.retrieved_edges == []
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pytest tests/test_familiar_adapter.py::test_query_happy_path -v`
+Expected: FAIL with `NotImplementedError: Task 4-7`.
+
+- [ ] **Step 3: Implement `query()` and `_post_json` helper**
+
+In `sme/adapters/familiar.py`, add at the top:
+
+```python
+import json
+import urllib.error
+import urllib.request
+```
+
+Add a private HTTP helper inside the class:
+
+```python
+def _post_json(self, path: str, body: dict) -> tuple[int, Any]:
+    """POST JSON, return (status, parsed_body). Raises only on
+    network/JSON failure; HTTP non-2xx is returned as a status tuple
+    for the caller to translate into an SME error."""
+    url = f"{self.base_url}{path}"
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    opener = self._opener or urllib.request.urlopen
+    try:
+        with opener(req, timeout=self.timeout_s) as resp:
+            raw = resp.read().decode("utf-8")
+            status = resp.status if hasattr(resp, "status") else resp.getcode()
+            return status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        # Non-2xx with a body — return status + best-effort body.
+        try:
+            raw = e.read().decode("utf-8", errors="replace")
+            try:
+                return e.code, json.loads(raw)
+            except json.JSONDecodeError:
+                return e.code, {"_raw": raw[:200]}
+        except Exception:
+            return e.code, {"_raw": ""}
+```
+
+Replace `query` body:
+
+```python
+def query(self, question: str) -> QueryResult:
+    """POST /api/familiar/eval and deserialize the SME-shape response."""
+    body = {
+        "query": question[:250],
+        "limit": 5,
+        "kind": "content",
+        "mock": self.mock_inference,
+    }
+    status, payload = self._post_json("/api/familiar/eval", body)
+    if status != 200:
+        snippet = json.dumps(payload)[:200] if isinstance(payload, dict) else str(payload)[:200]
+        return QueryResult(
+            answer="",
+            context_string="",
+            retrieved_entities=[],
+            retrieved_edges=[],
+            error=f"familiar endpoint {status}: {snippet}",
+        )
+    return self._deserialize_query(payload)
+
+
+def _deserialize_query(self, payload: dict) -> QueryResult:
+    """Map familiar's JSON response onto SME QueryResult."""
+    answer = payload.get("answer") or ""
+    context_string = payload.get("context_string") or ""
+    raw_entities = payload.get("retrieved_entities") or []
+    raw_edges = payload.get("retrieved_edges") or []
+    server_error = payload.get("error")
+    warnings = payload.get("warnings") or []
+
+    entities = [self._entity_from_payload(e) for e in raw_entities]
+    edges = [self._edge_from_payload(e) for e in raw_edges]
+
+    error = server_error
+    # warnings translation rules land in Task 7
+
+    return QueryResult(
+        answer=answer,
+        context_string=context_string,
+        retrieved_entities=entities,
+        retrieved_edges=edges,
+        error=error,
+    )
+
+
+@staticmethod
+def _entity_from_payload(p: dict) -> Entity:
+    """Map a familiar SmeEntity dict to an SME Entity dataclass."""
+    eid = p.get("id") or ""
+    return Entity(
+        id=eid,
+        name=eid,
+        entity_type=p.get("type") or "drawer",
+        properties={
+            k: v
+            for k, v in p.items()
+            if k not in ("id", "type") and v is not None
+        },
+    )
+
+
+@staticmethod
+def _edge_from_payload(p: dict) -> Edge:
+    return Edge(
+        source_id=p.get("subject") or "",
+        target_id=p.get("object") or "",
+        edge_type=p.get("predicate") or "",
+    )
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `pytest tests/test_familiar_adapter.py::test_query_happy_path -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): FamiliarAdapter.query happy path
+
+POSTs to /api/familiar/eval, deserializes the SME-shape response into
+QueryResult. mock_inference=True forwarded as 'mock' field so Cat 1
+scoring stays deterministic. _post_json helper handles HTTPError into
+status-tuple translation for non-throwing error contract."
+```
+
+---
+
+## Task 5: HTTP error contract (4xx, 5xx, network, JSON-malformed)
+
+**Files:**
+- Modify: `sme/adapters/familiar.py` (extend `_post_json`)
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+import socket
+import urllib.error
+
+
+def test_query_http_500(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval": (500, {"error": "internal"}),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("anything")
+    assert result.error is not None
+    assert "500" in result.error
+    assert result.retrieved_entities == []
+
+
+def test_query_http_400(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval": (400, {"error": "bad json"}),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("anything")
+    assert "400" in (result.error or "")
+
+
+def test_query_timeout(monkeypatch):
+    def raising_opener(*a, **kw):
+        raise socket.timeout("boom")
+    adapter = FamiliarAdapter(opener=raising_opener, timeout_s=2.0)
+    result = adapter.query("anything")
+    assert result.error is not None
+    assert "timeout" in result.error.lower() or "boom" in result.error
+
+
+def test_query_connection_refused(monkeypatch):
+    def raising_opener(*a, **kw):
+        raise urllib.error.URLError("Connection refused")
+    adapter = FamiliarAdapter(opener=raising_opener)
+    result = adapter.query("anything")
+    assert result.error is not None
+    assert "connection" in result.error.lower() or "refused" in result.error.lower()
+
+
+def test_query_invalid_json(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval": (200, "not json at all"),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("anything")
+    assert result.error is not None
+    assert "json" in result.error.lower()
+```
+
+- [ ] **Step 2: Run, observe failures (timeout/connection/JSON propagate raw)**
+
+Run: `pytest tests/test_familiar_adapter.py -v -k "http_500 or http_400 or timeout or connection or invalid_json"`
+Expected: 3-4 failures (the 4xx/5xx cases pass already from Task 4; timeout/connection/json propagate as exceptions).
+
+- [ ] **Step 3: Extend `_post_json` to catch network + JSON errors**
+
+In `sme/adapters/familiar.py`, replace `_post_json` body's `try`/`except` chain:
+
+```python
+def _post_json(self, path: str, body: dict) -> tuple[int, Any]:
+    """POST JSON, return (status, parsed_body). Translates network and
+    JSON-decode failures into a sentinel (-1 status, error-bearing dict)
+    so the adapter's error contract stays no-raise."""
+    url = f"{self.base_url}{path}"
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    opener = self._opener or urllib.request.urlopen
+    try:
+        with opener(req, timeout=self.timeout_s) as resp:
+            raw = resp.read().decode("utf-8")
+            status = resp.status if hasattr(resp, "status") else resp.getcode()
+            try:
+                parsed = json.loads(raw) if raw else {}
+            except json.JSONDecodeError as e:
+                return -1, {"_network_error": f"invalid JSON response: {e}"}
+            return status, parsed
+    except urllib.error.HTTPError as e:
+        try:
+            raw = e.read().decode("utf-8", errors="replace")
+            try:
+                return e.code, json.loads(raw)
+            except json.JSONDecodeError:
+                return e.code, {"_raw": raw[:200]}
+        except Exception:
+            return e.code, {"_raw": ""}
+    except (socket.timeout, TimeoutError) as e:
+        return -1, {"_network_error": f"timeout after {self.timeout_s}s ({e})"}
+    except urllib.error.URLError as e:
+        return -1, {"_network_error": f"connection failed: {e.reason}"}
+    except Exception as e:
+        return -1, {"_network_error": f"unexpected: {type(e).__name__}: {e}"}
+```
+
+Add at the top of the file with the other imports:
+```python
+import socket
+```
+
+Then update `query()` to handle the `-1` sentinel:
+
+```python
+def query(self, question: str) -> QueryResult:
+    body = {
+        "query": question[:250],
+        "limit": 5,
+        "kind": "content",
+        "mock": self.mock_inference,
+    }
+    status, payload = self._post_json("/api/familiar/eval", body)
+    if status == -1:
+        # Network/JSON failure — payload carries the message
+        msg = payload.get("_network_error", "unknown network error")
+        return QueryResult(
+            answer="",
+            context_string="",
+            retrieved_entities=[],
+            retrieved_edges=[],
+            error=f"familiar {msg}",
+        )
+    if status != 200:
+        snippet = json.dumps(payload)[:200] if isinstance(payload, dict) else str(payload)[:200]
+        return QueryResult(
+            answer="",
+            context_string="",
+            retrieved_entities=[],
+            retrieved_edges=[],
+            error=f"familiar endpoint {status}: {snippet}",
+        )
+    return self._deserialize_query(payload)
+```
+
+- [ ] **Step 4: Run all error tests, verify pass**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 9 passed (3 from Task 1, 1 from Task 3, 1 from Task 4, 5 new error tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): FamiliarAdapter HTTP/network error contract
+
+Returns QueryResult with error string for HTTPError, socket.timeout,
+URLError, and JSONDecodeError. Never raises; matches the SMEAdapter
+no-throw contract used by cmd_retrieve to distinguish 'errored' from
+'answered wrong' in the per-question scorecard."
+```
+
+---
+
+## Task 6: Warnings translation (soft + hard signals)
+
+**Files:**
+- Modify: `sme/adapters/familiar.py:_deserialize_query`
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+def _ok_response_with_warnings(warnings):
+    return {
+        "answer": "x",
+        "context_string": "x",
+        "retrieved_entities": [
+            {
+                "id": "drawer_x",
+                "type": "drawer",
+                "wing": "w",
+                "room": "r",
+                "content_snippet": "x",
+            }
+        ],
+        "retrieved_edges": [],
+        "error": None,
+        "warnings": warnings,
+    }
+
+
+def test_query_soft_warnings_become_warn_prefix(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval":
+            (200, _ok_response_with_warnings(["low_confidence", "filtered_null_text_1"])),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("x")
+    # Soft warnings: error gets a WARN prefix but data still flows
+    assert result.error is not None
+    assert "WARN" in result.error
+    assert "low_confidence" in result.error
+    assert "filtered_null_text_1" in result.error
+    assert len(result.retrieved_entities) == 1  # not zeroed out
+
+
+def test_query_palace_unreachable_is_hard_warning(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval":
+            (200, _ok_response_with_warnings(["palace_unreachable", "low_confidence"])),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("x")
+    assert result.error is not None
+    assert "palace_unreachable" in result.error
+    assert "WARN" in result.error
+
+
+def test_query_no_warnings_no_error(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval":
+            (200, _ok_response_with_warnings([])),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("x")
+    assert result.error is None
+
+
+def test_query_server_error_takes_precedence(fake_urlopen_factory):
+    payload = _ok_response_with_warnings(["low_confidence"])
+    payload["error"] = "explicit server error"
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval": (200, payload),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    result = adapter.query("x")
+    # When server says error, that's authoritative — warnings appended
+    assert "explicit server error" in (result.error or "")
+```
+
+- [ ] **Step 2: Run, observe failures**
+
+Run: `pytest tests/test_familiar_adapter.py -v -k "warning or unreachable or no_warnings or server_error"`
+Expected: 4 failures (Task 4's `_deserialize_query` doesn't yet translate warnings).
+
+- [ ] **Step 3: Implement warnings translation**
+
+In `sme/adapters/familiar.py`, update `_deserialize_query`:
+
+```python
+# Hard warnings — adapter-level error even though HTTP was 200.
+HARD_WARNING_TOKENS = ("palace_unreachable",)
+
+
+def _deserialize_query(self, payload: dict) -> QueryResult:
+    """Map familiar's JSON response onto SME QueryResult."""
+    answer = payload.get("answer") or ""
+    context_string = payload.get("context_string") or ""
+    raw_entities = payload.get("retrieved_entities") or []
+    raw_edges = payload.get("retrieved_edges") or []
+    server_error = payload.get("error")
+    warnings = payload.get("warnings") or []
+
+    entities = [self._entity_from_payload(e) for e in raw_entities]
+    edges = [self._edge_from_payload(e) for e in raw_edges]
+
+    parts: list[str] = []
+    if server_error:
+        parts.append(str(server_error))
+    if warnings:
+        parts.append("WARN: " + "; ".join(warnings))
+    error = " | ".join(parts) if parts else None
+
+    return QueryResult(
+        answer=answer,
+        context_string=context_string,
+        retrieved_entities=entities,
+        retrieved_edges=edges,
+        error=error,
+    )
+```
+
+The `HARD_WARNING_TOKENS` constant is currently informational; the
+distinction between soft and hard is recorded in `error` text which
+SME-side scoring already keys on for "errored" vs. "answered wrong".
+Future work can use `HARD_WARNING_TOKENS` to short-circuit data
+fields when the server explicitly says retrieval failed.
+
+- [ ] **Step 4: Run all tests, verify pass**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 13 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): FamiliarAdapter warnings translation
+
+Soft warnings (low_confidence, filtered_null_text_*, stuck_loop) and
+hard warnings (palace_unreachable) both surface in QueryResult.error
+with a WARN: prefix; entities/edges still flow so SME's per-question
+scoring distinguishes 'warned but answered' from 'errored'. Server-side
+'error' field takes precedence; warnings appended after the | separator."
+```
+
+---
+
+## Task 7: `get_graph_snapshot()` via shared mapping module
+
+**Files:**
+- Modify: `sme/adapters/familiar.py`
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+def test_get_graph_snapshot_happy_path(fake_urlopen_factory):
+    body = {
+        "wings": {"realmwatch": 12, "personal": 7},
+        "rooms": [
+            {"wing": "realmwatch", "rooms": {"gatekeeper": 5}},
+            {"wing": "personal", "rooms": {"hobbies": 4}},
+        ],
+        "tunnels": [{"room": "tools", "wings": ["realmwatch", "personal"]}],
+        "kg_entities": [
+            {"id": "ent_1", "name": "JP", "type": "person", "properties": {}}
+        ],
+        "kg_triples": [
+            {"subject": "ent_1", "predicate": "owns", "object": "ent_repo"}
+        ],
+        "kg_stats": {"entities": 1, "triples": 1},
+    }
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/graph": (200, body),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    entities, edges = adapter.get_graph_snapshot()
+
+    # Each wing is an entity
+    wing_ids = [e.id for e in entities if e.entity_type == "wing"]
+    assert "wing:realmwatch" in wing_ids
+    assert "wing:personal" in wing_ids
+
+    # Each KG entity prefixed kg:
+    kg_ids = [e.id for e in entities if e.entity_type == "person"]
+    assert "kg:ent_1" in kg_ids
+
+    # Tunnel produces a topic_tunnel edge between the two wings
+    tunnel_edges = [e for e in edges if e.edge_type == "topic_tunnel"]
+    assert any(
+        {edge.source_id, edge.target_id} == {"wing:realmwatch", "wing:personal"}
+        for edge in tunnel_edges
+    )
+
+
+def test_get_graph_snapshot_failure_returns_empty(fake_urlopen_factory):
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/graph": (502, {"error": "daemon down"}),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    entities, edges = adapter.get_graph_snapshot()
+    assert entities == []
+    assert edges == []
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `pytest tests/test_familiar_adapter.py::test_get_graph_snapshot_happy_path -v`
+Expected: FAIL with `NotImplementedError: Task 8`.
+
+- [ ] **Step 3: Implement `get_graph_snapshot` + `_get_json` GET helper**
+
+In `sme/adapters/familiar.py`, add the import:
+```python
+from sme.adapters._graph_mapping import project_graph
+```
+
+Add a GET helper to the class:
+
+```python
+def _get_json(self, path: str) -> tuple[int, Any]:
+    """GET JSON, mirror _post_json's no-raise contract."""
+    url = f"{self.base_url}{path}"
+    req = urllib.request.Request(url, method="GET")
+    opener = self._opener or urllib.request.urlopen
+    try:
+        with opener(req, timeout=self.timeout_s) as resp:
+            raw = resp.read().decode("utf-8")
+            status = resp.status if hasattr(resp, "status") else resp.getcode()
+            try:
+                parsed = json.loads(raw) if raw else {}
+            except json.JSONDecodeError as e:
+                return -1, {"_network_error": f"invalid JSON: {e}"}
+            return status, parsed
+    except urllib.error.HTTPError as e:
+        try:
+            raw = e.read().decode("utf-8", errors="replace")
+            try:
+                return e.code, json.loads(raw)
+            except json.JSONDecodeError:
+                return e.code, {"_raw": raw[:200]}
+        except Exception:
+            return e.code, {"_raw": ""}
+    except (socket.timeout, TimeoutError) as e:
+        return -1, {"_network_error": f"timeout after {self.timeout_s}s ({e})"}
+    except urllib.error.URLError as e:
+        return -1, {"_network_error": f"connection failed: {e.reason}"}
+    except Exception as e:
+        return -1, {"_network_error": f"unexpected: {type(e).__name__}: {e}"}
+```
+
+Replace `get_graph_snapshot`:
+
+```python
+def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
+    """GET /api/familiar/graph (familiar's proxy of palace-daemon /graph)
+    and project to (entities, edges) via the shared mapping module."""
+    status, body = self._get_json("/api/familiar/graph")
+    if status != 200 or not isinstance(body, dict) or "wings" not in body:
+        return [], []
+    return project_graph(body)
+```
+
+- [ ] **Step 4: Run all tests, verify pass**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 15 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): FamiliarAdapter.get_graph_snapshot via shared module
+
+GETs /api/familiar/graph (familiar's verbatim proxy of palace-daemon's
+/graph with a 5-min cache layer) and runs the response through the
+shared _graph_mapping.project_graph helper. Failure returns ([], []) to
+keep Cat 5/8 from raising; per the SME contract a missing snapshot just
+zeroes out structural-category scores for that run."
+```
+
+---
+
+## Task 8: Optional methods — `get_flat_retrieval`, `get_ontology_source`, `get_harness_manifest`
+
+**Files:**
+- Modify: `sme/adapters/familiar.py`
+- Test: `tests/test_familiar_adapter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+def test_get_flat_retrieval_returns_entities_only(fake_urlopen_factory):
+    body = _ok_response_with_warnings([])
+    body["retrieved_entities"] = [
+        {"id": f"d{i}", "type": "drawer", "wing": "w", "room": "r"}
+        for i in range(3)
+    ]
+    fake = fake_urlopen_factory({
+        "http://familiar:8080/api/familiar/eval": (200, body),
+    })
+    adapter = FamiliarAdapter(opener=fake)
+    entities = adapter.get_flat_retrieval("test", k=3)
+    assert len(entities) == 3
+    assert all(isinstance(e, type(entities[0])) for e in entities)
+
+
+def test_get_ontology_source_returns_declared():
+    adapter = FamiliarAdapter()
+    assert adapter.get_ontology_source() == "declared"
+
+
+def test_get_harness_manifest_returns_two_descriptors():
+    adapter = FamiliarAdapter(base_url="https://familiar.jphe.in")
+    manifest = adapter.get_harness_manifest()
+    # Forward-compat: returns [] if HarnessDescriptor types not importable;
+    # otherwise returns 2 descriptors. Either is acceptable.
+    assert isinstance(manifest, list)
+    assert len(manifest) in (0, 2)
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `pytest tests/test_familiar_adapter.py -v -k "get_flat_retrieval or get_ontology_source or get_harness"`
+Expected: 3 failures (methods don't exist yet).
+
+- [ ] **Step 3: Implement the three optional methods**
+
+In `sme/adapters/familiar.py`, add at the end of the class:
+
+```python
+def get_flat_retrieval(self, question: str, k: int = 5) -> list[Entity]:
+    """Optional: same path as query() but returns only the entities,
+    used by Cat 7 token-budget analysis where the answer text is
+    irrelevant and only retrieval changes."""
+    body = {
+        "query": question[:250],
+        "limit": k,
+        "kind": "content",
+        "mock": self.mock_inference,
+    }
+    status, payload = self._post_json("/api/familiar/eval", body)
+    if status != 200:
+        return []
+    raw_entities = payload.get("retrieved_entities") or []
+    return [self._entity_from_payload(e) for e in raw_entities]
+
+
+def get_ontology_source(self) -> str:
+    """Wings/rooms taxonomy is author-declared (mempalace_get_taxonomy
+    MCP tool), not inferred from data. Same semantics as
+    MemPalaceDaemonAdapter."""
+    return "declared"
+
+
+def get_harness_manifest(self) -> list:
+    """Forward-compat for SME Cat 9 (Handshake). Returns descriptors of
+    familiar's invocation surfaces — HTTP tool-call + MCP. Falls back to
+    [] when the multipass-side descriptor types aren't yet importable
+    (Cat 9 not implemented yet on this multipass version)."""
+    try:
+        from sme.harness import ToolCall, MCPResource  # type: ignore
+    except ImportError:
+        return []
+    return [
+        ToolCall(
+            name="familiar_query",
+            json_schema={
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+            backend_endpoint=f"{self.base_url}/api/familiar/eval",
+        ),
+        MCPResource(
+            server_url=f"{self.base_url}/mcp",
+            resource_uri_pattern="familiar_(recall|reflect|chat)",
+        ),
+    ]
+```
+
+- [ ] **Step 4: Run all tests, verify pass**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 18 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sme/adapters/familiar.py tests/test_familiar_adapter.py
+git commit -m "feat(adapters): FamiliarAdapter optional methods
+
+- get_flat_retrieval: same eval endpoint, entities only (Cat 7).
+- get_ontology_source: 'declared' — wings/rooms are author-defined.
+- get_harness_manifest: forward-compat Cat 9 — returns HTTP-tool +
+  MCP descriptors when sme.harness is importable, else [] for
+  graceful behavior on multipass versions before Cat 9 ships."
+```
+
+---
+
+## Task 9: CLI wiring — `--adapter familiar` + `--mock`/`--no-mock`
+
+**Files:**
+- Modify: `sme/cli.py:_load_adapter` + relevant argparse blocks
+- Test: `tests/test_familiar_adapter.py` (small CLI integration test)
+
+- [ ] **Step 1: Read the existing `_load_adapter` to see the dispatch shape**
+
+Run: `sed -n '20,80p' sme/cli.py`
+Expected: see the `if name == "ladybugdb"` and `if name in ("mempalace-daemon", ...)` branches that instantiate the right adapter and drop incompatible kwargs.
+
+- [ ] **Step 2: Add the familiar branch in `_load_adapter`**
+
+In `sme/cli.py`, in `_load_adapter`, add after the existing `mempalace-daemon` branch:
+
+```python
+if name == "familiar":
+    from sme.adapters.familiar import FamiliarAdapter
+
+    # Drop kwargs the familiar adapter doesn't understand
+    for k in (
+        "include_node_tables",
+        "include_edge_tables",
+        "auto_discover",
+        "kg_path",
+        "collection_name",
+        "default_query_mode",
+        "db_path",
+        "buffer_pool_size",
+        "api_key",      # familiar reads palace-daemon key from .env, not CLI
+        "kind",         # familiar always uses kind=content
+    ):
+        kwargs.pop(k, None)
+    return FamiliarAdapter(**kwargs)
+```
+
+- [ ] **Step 3: Add `--mock`/`--no-mock` flag handling**
+
+In `sme/cli.py`, locate the helper that builds adapter kwargs from args (search for `adapter_kwargs` definitions — there are several around `cmd_retrieve`, `cmd_check`, etc.). For each subcommand that accepts `--adapter`, add a mutually-exclusive `--mock`/`--no-mock` flag:
+
+Find the function `_add_db_or_api_args(parser)` (search `def _add_db_or_api_args`) and add at the end:
+
+```python
+mock_group = parser.add_mutually_exclusive_group()
+mock_group.add_argument(
+    "--mock", dest="mock_inference", action="store_true",
+    default=None,
+    help="(familiar adapter) skip inference, score retrieval only "
+         "(default: True for Cat 1 determinism)",
+)
+mock_group.add_argument(
+    "--no-mock", dest="mock_inference", action="store_false",
+    help="(familiar adapter) run inference; for future Cat 9 work",
+)
+```
+
+Then in each `cmd_*` helper that calls `_load_adapter`, add `mock_inference=args.mock_inference` to the kwargs. The pattern from `cmd_retrieve` (around `cli.py:782`):
+
+```python
+adapter_kwargs = {
+    "base_url": getattr(args, "base_url", None),
+    "timeout_s": getattr(args, "timeout", None),
+    "mock_inference": getattr(args, "mock_inference", None),
+    # ... existing keys
+}
+```
+
+- [ ] **Step 4: Add a small CLI integration test**
+
+Append to `tests/test_familiar_adapter.py`:
+
+```python
+import subprocess
+import sys
+
+
+def test_cli_loads_familiar_adapter():
+    """The CLI's --adapter familiar branch instantiates without error
+    when given a base-url. Doesn't actually query — instantiation only."""
+    # Use python -c to exercise the dispatch path without spinning a real CLI run
+    result = subprocess.run(
+        [
+            sys.executable, "-c",
+            "from sme.cli import _load_adapter; "
+            "a = _load_adapter('familiar', base_url='http://nowhere:1', timeout_s=1.0); "
+            "print(type(a).__name__)"
+        ],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "FamiliarAdapter" in result.stdout
+```
+
+- [ ] **Step 5: Run all tests + commit**
+
+Run: `pytest tests/test_familiar_adapter.py -v`
+Expected: 19 passed.
+
+```bash
+git add sme/cli.py tests/test_familiar_adapter.py
+git commit -m "feat(cli): wire --adapter familiar + --mock/--no-mock flags
+
+Adds the familiar branch to _load_adapter (mirrors the mempalace-daemon
+branch pattern, drops incompatible kwargs). Mutually-exclusive
+--mock/--no-mock toggles FamiliarAdapter.mock_inference; default is
+--mock for Cat 1 substring-scoring determinism. CLI integration test
+exercises the dispatch path."
+```
+
+---
+
+## Task 10: Live smoke test (gated by env)
+
+**Files:**
+- Create: `tests/test_familiar_live.py`
+
+- [ ] **Step 1: Write the gated smoke test**
+
+Create `tests/test_familiar_live.py`:
+
+```python
+"""Gated live-smoke test for FamiliarAdapter.
+
+Skipped unless FAMILIAR_BASE_URL is set, e.g.:
+    FAMILIAR_BASE_URL=http://familiar:8080 pytest tests/test_familiar_live.py
+
+Mirrors tests/test_mempalace_daemon_integration.py's pattern.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from sme.adapters.familiar import FamiliarAdapter
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("FAMILIAR_BASE_URL"),
+    reason="set FAMILIAR_BASE_URL to run live smoke",
+)
+
+
+@pytest.fixture
+def adapter() -> FamiliarAdapter:
+    return FamiliarAdapter(
+        base_url=os.environ["FAMILIAR_BASE_URL"],
+        timeout_s=15.0,
+        mock_inference=True,
+    )
+
+
+def test_live_query_returns_query_result(adapter: FamiliarAdapter):
+    """At minimum, query() returns a QueryResult — no exceptions
+    even if palace is rebuilding."""
+    result = adapter.query("realm projects")
+    # Don't assert non-empty results — palace HNSW may be rebuilding
+    # right now. Just verify the contract holds.
+    assert hasattr(result, "answer")
+    assert hasattr(result, "context_string")
+    assert hasattr(result, "retrieved_entities")
+    assert hasattr(result, "retrieved_edges")
+    if result.error:
+        # Acceptable error shapes
+        assert "WARN" in result.error or "endpoint" in result.error or "timeout" in result.error.lower()
+
+
+def test_live_get_graph_snapshot_returns_lists(adapter: FamiliarAdapter):
+    """Graph snapshot is cached server-side (5-min TTL) so this is fast
+    after the first call."""
+    entities, edges = adapter.get_graph_snapshot()
+    assert isinstance(entities, list)
+    assert isinstance(edges, list)
+    if not entities:
+        pytest.skip("graph endpoint returned empty — palace may be rebuilding")
+```
+
+- [ ] **Step 2: Verify test skips when env var is unset**
+
+Run: `pytest tests/test_familiar_live.py -v`
+Expected: 2 skipped.
+
+- [ ] **Step 3: Verify test runs when env var is set (against staging URL)**
+
+Run: `FAMILIAR_BASE_URL=https://familiar.jphe.in pytest tests/test_familiar_live.py -v`
+Expected: 2 passed (or graceful skip on graph snapshot if palace is mid-rebuild).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_familiar_live.py
+git commit -m "test(adapters): gated live smoke for FamiliarAdapter
+
+Set FAMILIAR_BASE_URL to run; otherwise skipped. Asserts the
+QueryResult contract holds and graph_snapshot returns lists. Tolerates
+palace HNSW rebuild state via skip+warn handling, so the test is robust
+against the operational degradation modes documented in
+familiar.realm.watch's reference_palace_hnsw_rebuild memory."
+```
+
+---
+
+## Task 11: README + docs/ideas.md updates
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/ideas.md`
+
+- [ ] **Step 1: Add familiar to the adapter table in README.md**
+
+Locate the existing adapter table in `README.md` (search for `mempalace-daemon`). Add a row matching the format:
+
+```markdown
+| `familiar`         | familiar.realm.watch v0.2 over HTTP — palace + rerank/decay/compress/grounding pipeline | Mode B (diagnostic) | `--adapter familiar --base-url <url>` |
+```
+
+- [ ] **Step 2: Add a "Running familiar adapter" subsection**
+
+In README.md's Quickstart area, parallel to the mempalace-daemon section, add:
+
+```markdown
+### Running familiar adapter
+
+`sme-eval` against a running familiar.realm.watch v0.2.0+ instance:
+
+    sme-eval retrieve \
+        --adapter familiar \
+        --base-url http://familiar:8080 \
+        --questions corpora/<your-corpus>.yaml \
+        --json /tmp/familiar-run.json
+
+Default `--mock` skips LLM inference for deterministic Cat 1 retrieval
+scoring. Pair with `--adapter mempalace-daemon` runs against the same
+palace to measure what familiar's v0.2 pipeline contributes on top of
+the underlying daemon.
+```
+
+- [ ] **Step 3: Update docs/ideas.md**
+
+In `docs/ideas.md`, find the section that says "Cat 9 is not implemented yet". Add a paragraph below it:
+
+```markdown
+**Forward-compat in adapters (2026-04-26):** `FamiliarAdapter` (familiar.realm.watch
+v0.2's adapter) emits per-question records that include the verbatim
+`context_string` sent to inference plus structured `warnings`
+(`palace_unreachable`, `low_confidence`, `filtered_null_text_*`,
+`stuck_loop`). The `cmd_retrieve` JSON output captures all of this
+per-question, so a future `sme/categories/handshake.py` scorer can
+compute Cat 9 metrics (9a invocation rate, 9b call-through success,
+9c result usage, 9d negative-control rate) from existing run
+artifacts without revisiting the adapter API. `get_harness_manifest()`
+is also implemented forward-compat — currently returns `[]` because
+this multipass version doesn't import `sme.harness.HarnessDescriptor`,
+but two descriptors (HTTP `ToolCall` + `MCPResource`) are emitted as
+soon as the harness types ship.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/ideas.md
+git commit -m "docs: add familiar adapter to README + Cat-9 forward-compat note
+
+Adapter table row + Quickstart subsection mirror the mempalace-daemon
+entries. ideas.md notes that familiar's per-question records are
+forward-compatible with the eventual sme/categories/handshake.py scorer."
+```
+
+---
+
+## Task 12: Final integration verification + PR prep
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Full pytest run**
+
+Run: `pytest -v --tb=short 2>&1 | tail -40`
+Expected: all tests pass; familiar adapter contributes ~19 unit + 2 gated live tests.
+
+- [ ] **Step 2: Lint**
+
+Run: `ruff check sme/adapters/familiar.py sme/adapters/_graph_mapping.py tests/test_familiar_adapter.py tests/test_familiar_live.py`
+Expected: no errors. Fix any warnings.
+
+- [ ] **Step 3: CLI smoke against the live deployed instance**
+
+Run:
+```bash
+sme-eval retrieve \
+    --adapter familiar \
+    --base-url https://familiar.jphe.in \
+    --questions corpora/standard_v0_1/questions.yaml \
+    --json /tmp/familiar-baseline.json \
+    --mock
+```
+
+Expected: produces `/tmp/familiar-baseline.json` with per-question records.
+Inspect a sample:
+```bash
+jq '.results[0]' /tmp/familiar-baseline.json
+```
+Expected: each result has `error` (possibly `WARN: ...` for soft warnings), `retrieved_entities`, `context_string`.
+
+- [ ] **Step 4: Run the same corpus against `mempalace-daemon` adapter for delta comparison**
+
+Run:
+```bash
+sme-eval retrieve \
+    --adapter mempalace-daemon \
+    --base-url http://disks:8085 \
+    --questions corpora/standard_v0_1/questions.yaml \
+    --json /tmp/daemon-baseline.json
+```
+
+Compare:
+```bash
+jq '[.results[] | select(.recall == 1)] | length' /tmp/familiar-baseline.json
+jq '[.results[] | select(.recall == 1)] | length' /tmp/daemon-baseline.json
+```
+Expected: both numbers print. The delta tells you whether familiar's v0.2 pipeline helped retrieval recall on this corpus.
+
+- [ ] **Step 5: Commit final state + open PR**
+
+```bash
+git status   # verify clean tree (all changes committed already)
+gh pr create \
+    --title "feat(adapters): FamiliarAdapter — SME adapter for familiar.realm.watch v0.2" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Adds `FamiliarAdapter` so SME can score familiar.realm.watch's v0.2
+retrieval pipeline (rerank/decay/compress/grounding) on top of the
+palace-daemon-backed palace. Sibling to `MemPalaceDaemonAdapter`;
+delta between the two = what familiar's pipeline contributes.
+
+Spec: `docs/superpowers/specs/2026-04-26-familiar-adapter-design.md`
+Plan: `docs/superpowers/plans/2026-04-26-familiar-adapter.md`
+
+## Changes
+
+- New `sme/adapters/familiar.py` (~400 lines) with the four required
+  + three optional `SMEAdapter` methods; mock_inference=True default
+  for Cat 1 determinism.
+- New `sme/adapters/_graph_mapping.py` shared module (extracted from
+  `mempalace_daemon.py`'s `_project_graph`); both adapters now reuse it.
+- `sme/cli.py` wires `--adapter familiar` + `--mock`/`--no-mock`.
+- `tests/test_familiar_adapter.py` — 19 unit tests against mocked HTTP.
+- `tests/test_familiar_live.py` — gated live smoke (FAMILIAR_BASE_URL).
+- README adapter table + Quickstart subsection.
+- docs/ideas.md note on Cat 9 forward-compat via FamiliarAdapter records.
+
+## Test plan
+
+- [ ] `pytest -v` all green
+- [ ] `ruff check` clean
+- [ ] CLI run against https://familiar.jphe.in produces non-empty
+      per-question JSON
+- [ ] Direct comparison run against mempalace-daemon on the same
+      corpus emits a recall delta
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Summary
+
+| Task | Tests added | Files touched |
+|---|---|---|
+| 1 — extract /graph mapping | 0 (existing tests stay green) | 2 |
+| 2 — adapter scaffold | 3 | 2 |
+| 3 — ingest_corpus stub | 1 | 2 |
+| 4 — query happy path | 1 | 2 |
+| 5 — HTTP error contract | 5 | 2 |
+| 6 — warnings translation | 4 | 2 |
+| 7 — get_graph_snapshot | 2 | 2 |
+| 8 — optional methods | 3 | 2 |
+| 9 — CLI wiring | 1 | 2 |
+| 10 — live smoke (gated) | 2 (skipped by default) | 1 |
+| 11 — README + ideas.md | 0 | 2 |
+| 12 — verify + PR | 0 | 0 |
+| **Total** | **19 unit + 2 gated live** | **2 created, 4 modified** |
+
+Adheres to TDD throughout. Twelve commits map 1:1 to logical changes; each commit's tests pass before moving to the next task.

--- a/docs/superpowers/specs/2026-04-25-mempalace-daemon-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-25-mempalace-daemon-adapter-design.md
@@ -1,0 +1,434 @@
+# `mempalace-daemon` adapter — design
+
+Date: 2026-04-25
+Status: design (pre-implementation)
+Spec author: Claude (with JP)
+
+## Goal
+
+Add a fork-specific `MemPalaceDaemonAdapter` that talks to a running
+[`palace-daemon`](https://github.com/jphein/palace-daemon) over HTTP, so SME can
+run Cat 4/5/8/9 against a live MemPalace install without violating the daemon's
+single-writer invariant. The shipped `MemPalaceAdapter` opens ChromaDB directly
+via `chromadb.PersistentClient`; that's incompatible with the daemon-strict
+architecture (two `PersistentClient` instances against the same palace = the
+multi-writer corruption case the daemon was built to prevent).
+
+## Non-goals
+
+- Replace the existing `MemPalaceAdapter`. It stays. New adapter is additive,
+  for users who run the daemon. Documented in README.
+- Bench against a seeded corpus. Daemon adapter is diagnostic-only (Mode B), same
+  as the existing `MemPalaceAdapter`. `ingest_corpus` raises `NotImplementedError`.
+- Replicate every projection the direct adapter offers. Drawer-level entities
+  and per-source-file sibling edges are unreachable through the daemon API
+  surface; the spec accepts a coarser snapshot for the daemon path.
+
+## Why now
+
+Verified on 2026-04-25 against the live 151K-drawer palace at
+`disks.jphe.in:8085`:
+
+- `/search?kind=content` already implements the README-roadmapped filter that
+  excludes Stop-hook auto-save checkpoints. Default since 2026-04-25 in
+  `palace-daemon` 1.5.1.
+- `/search` with `q=memory&kind=content` produced `vector search unavailable:
+  Error executing plan: Internal error: Error finding id` while `q=hello&kind=all`
+  on the same daemon returned normal results. That's exactly the
+  integration-under-production-model gap (engram-2 critique) Cat 9 is designed
+  to catch — and an SME adapter is the right tool to characterise it.
+- The four MCP tools the README's roadmap planned to use (`list_wings`,
+  `list_rooms`, `list_tunnels`, `mempalace_kg_query`) work but are slow over
+  HTTP — `list_wings` took ~30s on the 151K-drawer palace. `list_tunnels`
+  returned `[]` while `/stats.tunnel_rooms` reported 9, indicating a real
+  daemon-side inconsistency we should fix in passing.
+- Adding a `/graph` REST endpoint on the daemon is a 30-40 line follow-on:
+  parallel-gather of the four tools server-side plus a direct read of
+  `~/.mempalace/knowledge_graph.sqlite3`, mirroring the existing `/stats`
+  pattern at `palace-daemon/main.py:452-461`.
+
+## Architecture
+
+Three components, each independently understandable.
+
+### Component A — `MemPalaceDaemonAdapter` (new file `sme/adapters/mempalace_daemon.py`)
+
+Implements `SMEAdapter`. Single class, ~200-300 lines.
+
+Constructor signature:
+
+```python
+class MemPalaceDaemonAdapter(SMEAdapter):
+    def __init__(
+        self,
+        *,
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        env_file: Optional[str | Path] = None,    # default: ~/.config/palace-daemon/env
+        kind: str = "content",                     # default kind for query()
+        api_timeout: float = 180.0,
+        prefer_graph_endpoint: bool = True,        # try GET /graph before MCP fallback
+        # accepted for CLI parity, ignored:
+        read_only: bool = True,
+        db_path: Optional[str] = None,
+    ): ...
+```
+
+Resolution rules for URL/key:
+
+1. Explicit `api_url` / `api_key` kwargs win.
+2. Else, parse `env_file` (default `~/.config/palace-daemon/env`) for
+   `PALACE_DAEMON_URL` and `PALACE_API_KEY`. Trust mode 600 set by the daemon
+   installer; do not warn on permissive modes (the daemon does that itself).
+3. Else, read process env (`PALACE_DAEMON_URL`, `PALACE_API_KEY`).
+4. If still missing, `ValueError` at construction with a message naming both
+   `--api-url`/`--api-key` flags and `~/.config/palace-daemon/env`.
+
+#### `query(question, *, n_results=5, kind=None, route=False)`
+
+```
+GET  {api_url}/search?q=<question>&limit=<n_results>&kind=<kind or self.kind>
+hdr  X-API-Key: <api_key>
+```
+
+Daemon response envelope:
+
+```json
+{
+  "query": "...",
+  "filters": {"wing": null, "room": null},
+  "total_before_filter": <int>,
+  "available_in_scope": <int>,
+  "warnings": ["..."],
+  "results": [
+    {"text": "...", "metadata": {"wing": "...", "room": "...", "source_file": "..."}, "score": ...}
+  ]
+}
+```
+
+Mapping to `QueryResult`:
+
+- `context_string`: `[i] [wing/room] source_basename\ntext` per result. Format
+  matches the existing `MemPalaceAdapter` so tiktoken counts (Cat 7 metric) are
+  comparable across the two adapters and the flat baseline.
+- `retrieved_entities`: one Entity per result, `id=f"drawer_hit:{i}"`,
+  `entity_type=f"drawer:{room}"`, properties carry wing/room/score/source_file.
+- `retrieval_path`: `[f"kind={chosen_kind}", f"available_in_scope={n}",
+  f"total_before_filter={n}"]`.
+- `warnings` from envelope: appended into `error` as `f"WARN: {'; '.join(warnings)}"`.
+  Soft signal — does **not** zero out the result. This is the critical decision
+  for Cat 9: a working-but-flagged response is different from a hard failure,
+  and SME's scorecard already distinguishes "errored" from "answered wrong" in
+  the per-question output (`sme/cli.py:782-832`).
+- `error="NO_RESULTS"` if `results` is empty *and* warnings is empty.
+- `route` kwarg: accepted for CLI signature parity with the existing
+  `MemPalaceAdapter`. Ignored — the daemon does its own routing. Documented in
+  the docstring.
+
+Per-call timeout: `api_timeout` (default 180s). Connection/HTTP errors return
+`QueryResult(error=...)`, never raise. Match the LadybugDB adapter's pattern
+at `sme/adapters/ladybugdb.py:259-280`.
+
+#### `get_graph_snapshot()`
+
+Two-phase strategy:
+
+1. **Fast path: `GET /graph`** (Component B below). If the daemon supports it
+   (200 OK), parse the response and project to `(Entity, Edge)`. Done.
+2. **Fallback path:** if `/graph` 404s (older daemons, upstream forks), call
+   `mempalace_list_wings` once + `mempalace_list_rooms(wing=W)` per wing in
+   sequence + `mempalace_list_tunnels` once via `POST /mcp`. KG entities/triples
+   skipped in fallback (the MCP `kg_query` tool requires arguments we can't
+   enumerate from outside).
+
+Projection (matches the existing direct adapter's wing/room/tunnel layer at
+`sme/adapters/mempalace.py:368-437`):
+
+- `Entity(id=f"wing:{name}", entity_type="wing", ...)` per wing
+- `Entity(id=f"room:{name}", entity_type=f"room:{primary_hall_or_untyped}",
+  properties={wings: [...], drawer_count: n}, ...)` per room
+- `Edge(member_of)` per (room, wing) pair
+- `Edge(tunnel)` between every wing-pair sharing a room (matches `palace_graph`
+  semantics)
+
+When KG data is present (fast path only):
+
+- `Entity(id=f"kg:{id}", entity_type=f"kg:{type}", ...)` per KG entity
+- `Edge(source_id=f"kg:{subj}", target_id=f"kg:{obj}", edge_type=predicate, ...)`
+  per triple, with confidence/source/valid_from in properties
+
+The daemon path's snapshot is structurally **coarser** than the direct
+adapter's: no per-drawer entities, no `same_file` sibling edges, no `filed_in`
+edges. This is by design — `mempalace_list_drawers` exists, but iterating it
+over HTTP for 151K drawers is impractical, and a per-drawer bulk endpoint is
+out of scope for this work. Documented in the adapter docstring and surfaced
+via `log.warning` on snapshot. If a future daemon ships a streaming
+`/drawers` endpoint, the adapter can pick it up with no contract change.
+
+#### `get_ontology_source()`
+
+Returns the same `readme`-typed dict the existing `MemPalaceAdapter` returns at
+`sme/adapters/mempalace.py:594-624`, so Cat 8 results are comparable across
+the two adapters. The schema *as documented* doesn't change just because the
+backend access path does.
+
+#### `close()`
+
+Releases nothing (no persistent connection). Safe to call multiple times.
+
+### Component B — `GET /graph` on `palace-daemon`
+
+> **Coordination note (2026-04-25):** JP is actively working on the
+> `palace-daemon` repo. This spec describes the endpoint shape we want; the
+> actual daemon-side change should be picked up by JP's current pass (or
+> queued as a follow-up) rather than landed by SME-side work in parallel.
+> The SME adapter ships and works without `/graph` (MCP fallback path),
+> so the SME side does not block on the daemon side.
+
+New endpoint, mirrors `/stats` (`palace-daemon/main.py:452-461`).
+
+```python
+@app.get("/graph")
+async def graph(x_api_key: str | None = Header(default=None)):
+    _check_auth(x_api_key)
+    # Phase 1: parallel-gather the once-per-palace tools
+    def call(tool, args):
+        return _call({"jsonrpc": "2.0", "id": 1,
+                      "method": "tools/call",
+                      "params": {"name": tool, "arguments": args}})
+    wings_resp, tunnels_resp, kg_stats_resp = await asyncio.gather(
+        call("mempalace_list_wings", {}),
+        call("mempalace_list_tunnels", {}),
+        call("mempalace_kg_stats", {}),
+    )
+    wings = _unwrap(wings_resp).get("wings", {})
+    # Phase 2: parallel list_rooms per wing
+    room_responses = await asyncio.gather(*[
+        call("mempalace_list_rooms", {"wing": w}) for w in wings
+    ])
+    rooms = [
+        {"wing": w, "rooms": _unwrap(r).get("rooms", {})}
+        for w, r in zip(wings, room_responses)
+    ]
+    # Phase 3: KG entities + triples via direct sqlite read
+    kg_entities, kg_triples = _read_kg_direct()
+    return {
+        "wings": wings,
+        "rooms": rooms,
+        "tunnels": _unwrap(tunnels_resp),
+        "kg_entities": kg_entities,
+        "kg_triples": kg_triples,
+        "kg_stats": _unwrap(kg_stats_resp),
+    }
+```
+
+`_read_kg_direct()` opens `~/.mempalace/knowledge_graph.sqlite3` read-only from
+inside the daemon process. Daemon already owns the palace SQLite — adding a
+parallel KG read does not violate the single-writer invariant (KG is a separate
+DB file from the ChromaDB persistent client; the daemon was the only thing
+holding the file open already in code paths that touch it).
+
+Bumps daemon `VERSION` from 1.5.1 → 1.6.0 (minor: additive endpoint).
+
+#### Bonus fix (small, in scope): `list_tunnels` inconsistency
+
+`/stats.tunnel_rooms` reports 9 for the live palace; `mempalace_list_tunnels`
+returns `[]`. Investigate and fix as part of the same PR. Likely a stale-cache
+or schema-shift bug in the MCP tool's implementation. The /graph endpoint
+should not propagate that inconsistency.
+
+### Component C — CLI plumbing
+
+Touched files: `sme/cli.py`. No new files.
+
+1. Extend `_load_adapter` to accept `mempalace-daemon` (and the alias
+   `mempalace_daemon`):
+
+   ```python
+   if name in ("mempalace-daemon", "mempalace_daemon"):
+       from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+       for k in (
+           "include_node_tables", "include_edge_tables", "auto_discover",
+           "kg_path", "collection_name", "default_query_mode",
+           "db_path",  # daemon adapter doesn't take a file path
+       ):
+           kwargs.pop(k, None)
+       return MemPalaceDaemonAdapter(**kwargs)
+   ```
+
+2. Extend `_load_adapter_from_args` (`cli.py:437-456`) to thread `--api-url`,
+   `--api-key`, and `--kind` (already done for `api_url`).
+
+3. Add `--api-key` and `--kind` to `_add_db_or_api_args` (`cli.py:464-479`):
+
+   ```python
+   parser.add_argument("--api-key", default=None, metavar="KEY",
+       help="API key for the daemon's X-API-Key header. Defaults to "
+            "PALACE_API_KEY from ~/.config/palace-daemon/env when present.")
+   parser.add_argument("--kind", default=None, metavar="KIND",
+       help="(mempalace-daemon) /search kind filter. Defaults to "
+            "'content'. Use 'all' to disable, 'checkpoint' to query "
+            "auto-save snapshots only.")
+   ```
+
+4. Add the same flags to `cmd_retrieve`'s subparser (`cli.py:993-1056`).
+
+5. Make `--db` optional for the `retrieve` and `analyze` subparsers so the
+   daemon adapter doesn't have to pass a meaningless path. Already optional
+   in `_add_db_or_api_args` for cat4/cat5/check.
+
+## Data flow (one diagram)
+
+```
+sme-eval retrieve --adapter mempalace-daemon \
+    --api-url http://disks.jphe.in:8085 --questions corpus.yaml --kind content
+       │
+       ▼
+   cmd_retrieve  ─────────►  _load_adapter("mempalace-daemon", api_url=..., api_key=..., kind="content")
+                                   │
+                                   ▼
+                             MemPalaceDaemonAdapter.__init__
+                                   │  resolves api_url, api_key from env file if needed
+                                   ▼
+                             query(question)  ──► GET /search?q=...&kind=content
+                                                       │
+                                                       ▼ X-API-Key header
+                                                  palace-daemon FastAPI
+                                                       │
+                                                       ▼
+                                                  mempalace_search MCP tool
+                                                       │
+                                                       ▼
+                                                  ChromaDB (kind filter applied
+                                                  pre-vector by daemon code)
+                                                       │
+                                                       ▼ envelope w/ warnings
+                                              QueryResult{context_string, error="WARN:..."}
+                                                       │
+                                                       ▼
+                                              cmd_retrieve scoring loop
+                                                       │
+                                                       ▼
+                                              JSON output (--json) for cat2c
+```
+
+## Error handling
+
+| Failure | Adapter response |
+|---|---|
+| No `api_url` (no flag, no env file, no env var) | `ValueError` at construction |
+| Connection refused / DNS fail | `QueryResult(error="CONNECTION: ...")` |
+| HTTP 401/403 | `QueryResult(error="AUTH: invalid X-API-Key")` |
+| HTTP 5xx | `QueryResult(error=f"HTTP {code}: {body[:200]}")` |
+| Daemon `warnings` non-empty | `QueryResult(error="WARN: ...")` — soft signal |
+| Empty `results` and empty `warnings` | `QueryResult(error="NO_RESULTS")` |
+| `/graph` returns 404 | log warning, fall back to MCP tool path |
+| MCP timeout (>180s) on `list_wings` | log warning, return partial snapshot (whatever wings/rooms succeeded) |
+| `list_rooms` for one wing fails | skip that wing's rooms, continue |
+| Env file unreadable | log warning, fall through to env vars |
+
+The "WARN: ..." in `error` for present-but-flagged responses is the load-bearing
+choice. The existing `cmd_retrieve` flow at `cli.py:782-829` records the error
+field in the JSON output but still uses `recall` from the substring match —
+which means SME can score Cat 9 even when the daemon reports "vector search
+unavailable", and the report distinguishes warning-tagged hits from clean ones.
+Cat 9's whole point is to surface integration-under-production-model gaps; the
+warnings ARE that signal.
+
+## Testing
+
+### Unit tests
+
+New file `tests/test_mempalace_daemon_adapter.py`:
+
+- `test_resolve_from_env_file_when_no_kwargs`: temp env file with the two vars,
+  no kwargs → adapter resolves both
+- `test_explicit_kwargs_win_over_env_file`
+- `test_query_success`: mock urlopen returns canned envelope, assert
+  `context_string` format and `retrieval_path`
+- `test_query_warnings_emit_soft_error`: envelope with non-empty warnings
+  produces `error.startswith("WARN:")` *and* keeps `context_string` populated
+- `test_query_no_results_returns_no_results_error`
+- `test_query_auth_error`: mocked HTTPError 401 → `error.startswith("AUTH:")`
+- `test_query_connection_error`: URLError → `error.startswith("CONNECTION:")`
+- `test_get_graph_snapshot_via_graph_endpoint`: mock /graph response
+- `test_get_graph_snapshot_falls_back_to_mcp_on_404`
+- `test_get_graph_snapshot_partial_on_mcp_timeout`
+
+Mock pattern: monkeypatch `urllib.request.urlopen` with a callable returning a
+context-manager-shaped object. Same pattern the existing test suite would use
+if it had any (it doesn't yet — the LadybugDB API path isn't unit-tested either,
+which is itself a gap, but out of scope here).
+
+### Integration smoke (gated)
+
+`tests/test_mempalace_daemon_integration.py`, gated on:
+
+```python
+@pytest.mark.skipif(
+    not os.environ.get("PALACE_DAEMON_URL"),
+    reason="needs a running palace-daemon",
+)
+```
+
+- `test_query_returns_query_result`: `query("hello")` returns a `QueryResult`
+- `test_get_graph_snapshot_returns_at_least_one_wing`
+- `test_kind_content_default_is_applied`: same query under `kind="all"` and
+  `kind="content"` produces different `total_before_filter` counts (validates
+  the README's filter claim)
+
+### Daemon-side test (palace-daemon repo)
+
+A unit test for the new `/graph` endpoint following the existing test-style
+in palace-daemon's tests directory. Out of scope for the SME repo's CI but
+tracked as an explicit deliverable in the implementation plan.
+
+### CLI smoke
+
+```bash
+sme-eval retrieve --adapter mempalace-daemon \
+    --questions tests/fixtures/tiny_corpus.yaml --json /tmp/out.json
+```
+
+Should produce a JSON output with one record per question, no exceptions
+raised even when the daemon emits warnings. Tested against a small
+local-mock-server fixture (existing test infrastructure has none — we add a
+minimal fixture as part of this work).
+
+## Build sequence (sketch — full plan in writing-plans output)
+
+1. Add `MemPalaceDaemonAdapter` with MCP-fallback graph path (no `/graph`
+   dependency yet). All unit tests pass.
+2. Wire CLI: `_load_adapter` branch + `--api-key` + `--kind` flags. Smoke-test
+   `retrieve` against the live daemon; capture before-state baseline JSON.
+3. Update README: replace the "planned" roadmap section with a "shipped"
+   section pointing at the adapter, the `--kind` flag, and example invocations.
+   Note that `/graph` fast path is pending the daemon side.
+4. **(Daemon-side, JP-driven, separate session/PR)** Add `/graph` endpoint to
+   palace-daemon, plus `list_tunnels` consistency fix. Bump daemon to 1.6.0.
+   Deploy.
+5. **(SME-side follow-up)** Adapter `prefer_graph_endpoint=True` becomes the
+   default fast path once 1.6.0 is live; MCP fallback retained. Re-run smoke;
+   capture after-state baseline.
+
+Steps 1-3 are the SME-fork-only deliverable for this spec. They ship the
+adapter against the existing daemon (`palace-daemon` 1.5.1) using the MCP
+fallback path — slower for cat4/5/check but functionally complete.
+Steps 4-5 are coordinated work tied to JP's current daemon changes.
+
+## Open questions
+
+None blocking. Three minor points the implementation will resolve in passing:
+
+- Exact response shape for `mempalace_list_tunnels` once the inconsistency is
+  fixed (the empty-list response we get today is wrong, but we don't yet know
+  what right looks like — clarified during step 3).
+- Whether `kg_query` requires a subject filter or supports a "list all triples"
+  mode. If not, the daemon-side direct sqlite read path is the only way.
+  The /graph endpoint takes that path regardless, so this doesn't block the
+  adapter.
+- Whether to add an `sme-eval cat9` subcommand as part of this work. Spec v8's
+  Cat 9 is the harness-integration test that motivates this whole adapter.
+  Out of scope for this design; the `retrieve` subcommand already runs the
+  measurements that Cat 9's scoring would consume. Cat 9 itself is a separate
+  spec.

--- a/docs/superpowers/specs/2026-04-26-familiar-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-26-familiar-adapter-design.md
@@ -1,0 +1,392 @@
+# `familiar` adapter — design
+
+Date: 2026-04-26
+Status: design (pre-implementation)
+Spec author: Claude (with JP)
+
+## Goal
+
+Add `FamiliarAdapter` to multipass — a fifth `SMEAdapter` implementation that
+talks to a running [`familiar.realm.watch`](https://github.com/jphein/familiar.realm.watch)
+v0.2.0+ instance over HTTP. Familiar is a TS+Bun chat surface that wraps
+palace-daemon with a v0.2 retrieval pipeline (rerank + decay + compress +
+grounding directives). The adapter measures **familiar's full pipeline**, not
+just the underlying palace.
+
+The adapter is sibling to `MemPalaceDaemonAdapter` (shipped 2026-04-25). Both
+target the same palace; the difference is the layer above it. Comparing their
+SME scores measures what familiar's v0.2 pipeline is worth.
+
+## Non-goals
+
+- **Cat 9 implementation.** Familiar's v0.2 already emits the full
+  `HandshakeTrace`-shaped data per turn (verified: chunk D's `Trace`
+  abstraction + `?trace=1` SSE event includes `query`, `retrieved`,
+  `context_string`, `answer`, `citations`, `warnings`, `duration_ms`).
+  The `cmd_retrieve` JSON output records all of this per-question. A future
+  `sme/categories/handshake.py` scorer can compute 9a-9d from the existing
+  per-question records. **Out of scope here:** building that scorer.
+  In scope: making sure the adapter emits enough data that the future
+  scorer doesn't need to revisit the adapter API.
+- **Replace `MemPalaceDaemonAdapter`.** It stays. The two adapters answer
+  different questions (palace alone vs palace + v0.2 pipeline). Both are
+  diagnostic; neither replaces the other.
+- **Bench against a seeded corpus** (Mode A). Familiar reads palace data
+  it didn't author. Like the daemon adapter, this is Mode B (diagnostic
+  on a live install). `ingest_corpus` returns a stub.
+- **Inference-mode runs.** Cat 1's substring scoring is deterministic only
+  when the LLM doesn't write the answer. Adapter defaults to `mock=true`
+  so retrieval scoring is reproducible. Inference-mode runs are reserved
+  for a future Cat 9 pass that scores answer text against expected
+  drawer hits via the same multipass LLM-judge pipeline (Cats 1, 7).
+
+## Why now
+
+Verified 2026-04-26 against `https://familiar.jphe.in/`:
+
+- `POST /api/familiar/eval` returns the full SME-`QueryResult` shape
+  natively. Familiar's v0.2 was designed around this contract (Phase 5
+  of its v0.2 plan, written 2026-04-24). No translation layer needed —
+  the adapter is mostly deserialization.
+- `GET /api/familiar/graph` proxies the daemon's `/graph` with a 5-min
+  cache. Reuse `MemPalaceDaemonAdapter`'s graph-snapshot mapping helpers
+  verbatim (the underlying `/graph` payload shape is identical because
+  familiar passes it through unchanged).
+- Familiar's v0.2 pipeline is now live in production with real palace
+  recall (post-rebuild 2026-04-25). The retrieval-quality delta vs.
+  `MemPalaceDaemonAdapter` is the single most operationally useful number
+  we don't have yet — without it we cannot say whether v0.2's
+  rerank/decay/compress chain is actually worth its complexity.
+- Familiar v0.2 also surfaces the warnings array directly from search
+  through to the eval response. The `low_confidence`,
+  `filtered_null_text_N`, `palace_unreachable`, `stuck_loop` warnings
+  characterise *operational degradations* of the chat surface — exactly
+  the production-integration gaps Cat 9 will eventually surface.
+  Capturing them per-question now prepares for that.
+
+## Adapter positioning
+
+```
++-----------------------+----------------------------------------------------+
+| SME adapter family                                                         |
++-----------------------+----------------------------------------------------+
+| flat_baseline.py      | no structure, no graph                             |
+| ladybugdb.py          | alt graph DB, baseline                             |
+| mempalace.py          | palace as a Python library (multi-writer risk)     |
+| mempalace_daemon.py   | palace via the daemon's HTTP API (single-writer    |
+|                       |   safe; what runs against live disks)              |
+| familiar.py NEW       | palace via daemon + v0.2 pipeline                  |
++-----------------------+----------------------------------------------------+
+```
+
+`mempalace_daemon` answers *"how good is the palace's recall on this corpus?"*
+`familiar` answers *"how good is the palace's recall **after familiar's
+pipeline acts on it**?"* Both target the same backing data.
+
+## Components
+
+### 1. `sme/adapters/familiar.py` — the adapter (~400 lines)
+
+```python
+class FamiliarAdapter(SMEAdapter):
+    DEFAULT_BASE_URL = "http://familiar:8080"
+    DEFAULT_TIMEOUT_S = 30.0
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        mock_inference: bool = True,
+        opener: Callable | None = None,  # for fake_urlopen_factory tests
+    ): ...
+```
+
+Three required methods + two optional + one Cat-9 forward-compat optional.
+
+#### `ingest_corpus(corpus)` — no-op stub
+
+Return:
+
+```python
+{
+    "entities_created": 0,
+    "edges_created": 0,
+    "errors": [],
+    "warnings": [
+        "FamiliarAdapter is diagnostic-only (Mode B). Familiar reads "
+        "palace data it didn't author; ingestion happens upstream via "
+        "`mempalace mine`. ingest_corpus is a no-op."
+    ],
+}
+```
+
+Same idiom as `MemPalaceDaemonAdapter`. Multipass's CLI tolerates this
+(checked in `cmd_ingest` of `cli.py`).
+
+#### `query(question)` returns `QueryResult`
+
+`POST /api/familiar/eval` with body:
+
+```json
+{
+  "query":  "<question, sliced to 250 chars>",
+  "limit":  5,
+  "kind":   "content",
+  "mock":   true
+}
+```
+
+Response shape (per familiar v0.2's `SmeQueryResponse`):
+
+```json
+{
+  "answer":             "(stub when mock=true)",
+  "context_string":     "<verbatim system prompt familiar would send>",
+  "retrieved_entities": [SmeEntity, ...],
+  "retrieved_edges":    [],
+  "error":              null,
+  "warnings":           ["low_confidence", "filtered_null_text_1", ...],
+  "available_in_scope": 151478
+}
+```
+
+Adapter deserialization rules:
+
+| field on the wire | maps to `QueryResult` field | rules |
+|---|---|---|
+| `answer` | `answer` | verbatim |
+| `context_string` | `context_string` | verbatim — multipass tiktoken-counts this for Cat 7 |
+| `retrieved_entities` | `retrieved_entities` (list[Entity]) | each `SmeEntity` becomes `Entity(id, name=id, entity_type="drawer", properties={wing, room, topic, content_snippet, cosine, bm25, matched_via, provenance})` |
+| `retrieved_edges` | `retrieved_edges` | empty in v0.2; map directly |
+| `error` | `error` | verbatim — `None` when null |
+| `warnings` non-fatal | append to `error` | format: `error or "" + " WARN: " + "; ".join(warnings)` so non-fatal signals reach the per-question record without zeroing out the result |
+| `warnings` containing `palace_unreachable` | `error = "WARN: palace_unreachable"` | hard signal — palace was down for this turn |
+| HTTP non-2xx | `error = f"familiar endpoint {status}: {body[:200]}"` | no exception propagation |
+| network/timeout | `error = f"familiar timeout after {timeout_s}s"` | no retries |
+
+Setting `error` instead of raising is the SMEAdapter contract — `cmd_retrieve`
+distinguishes "errored" from "answered wrong" in the per-question scorecard.
+
+#### `get_graph_snapshot()` returns `(list[Entity], list[Edge])`
+
+`GET /api/familiar/graph`. Familiar proxies the palace-daemon `/graph`
+endpoint with a 5-min cache. The payload shape is identical to what
+`MemPalaceDaemonAdapter` already maps:
+
+```json
+{
+  "wings":       {"<wing_name>": <drawer_count>, ...},
+  "rooms":       [{"wing": "...", "rooms": {"<room>": <count>}}, ...],
+  "tunnels":     [{"room": "...", "wings": [...]}, ...],
+  "kg_entities": [{"id", "name", "type", "properties": {...}}, ...],
+  "kg_triples":  [{"subject", "predicate", "object", ...}, ...],
+  "kg_stats":    {"entities": int, "triples": int}
+}
+```
+
+**Implementation:** extract the `MemPalaceDaemonAdapter`'s mapping helpers
+into a shared module (`sme/adapters/_mempalace_graph.py`) and reuse them
+verbatim. Don't fork the mapping; if the upstream `/graph` shape evolves,
+both adapters should follow.
+
+On HTTP failure or 5xx: return `([], [])` and log a warning. Cat 5/8 score
+0 for that run, which is the expected SME behavior for a missing snapshot.
+
+#### `get_flat_retrieval(question, k)` (optional)
+
+`POST /api/familiar/eval` with `mock=true`, `limit=k`. Return only
+`retrieved_entities` (no answer, no context_string). Used by SME's
+flat-baseline comparison passes (Cat 7 token-budget analysis).
+
+#### `get_ontology_source()` (optional)
+
+Returns `"declared"`. Familiar reads palace taxonomy via
+`mempalace_get_taxonomy` MCP tool — wings/rooms are author-declared, not
+inferred. Same semantics as `MemPalaceDaemonAdapter`.
+
+#### `get_harness_manifest()` (optional, Cat 9 forward-compat)
+
+```python
+def get_harness_manifest(self) -> list[HarnessDescriptor]:
+    """Familiar exposes two invocation surfaces — describe both for
+    future Cat 9 cross-harness comparison."""
+    return [
+        ToolCall(
+            name="familiar_query",
+            json_schema=...,
+            backend_endpoint=f"{self.base_url}/api/familiar/eval",
+        ),
+        MCPResource(
+            server_url=f"{self.base_url}/mcp",
+            resource_uri_pattern="familiar_recall|familiar_reflect|familiar_chat",
+        ),
+    ]
+```
+
+Returns `[]` if `HarnessDescriptor` isn't importable (older multipass).
+This is the only forward-looking method in the adapter — when Cat 9
+ships, this manifest tells multipass which harnesses to exercise.
+
+### 2. CLI wiring — `sme/cli.py`
+
+Mirror `--adapter mempalace-daemon` flag:
+
+```bash
+sme-eval retrieve \
+    --adapter familiar \
+    --base-url https://familiar.jphe.in \
+    --questions corpora/<your-corpus>.yaml \
+    --json scores.json \
+    [--mock | --no-mock]   # default --mock for Cat 1 determinism
+    [--timeout 30.0]
+```
+
+`--adapter familiar` instantiates `FamiliarAdapter(base_url=..., timeout_s=...,
+mock_inference=...)`. Default base URL is `http://familiar:8080` to support
+LAN runs from disks/katana without needing TLS.
+
+### 3. README + docs
+
+- Add familiar to the README adapter table (matching the row format used
+  for mempalace-daemon).
+- Add a "Running familiar adapter" subsection to README's Quickstart,
+  parallel to the existing daemon-adapter section.
+- Update `docs/ideas.md` to reflect that familiar supplies the adapter
+  layer of the eventual Cat 9 implementation; the per-question JSON
+  output already captures the data the future scorer will consume.
+
+## Data flow (per `query()`)
+
+```
+multipass cli              FamiliarAdapter           familiar-api          palace-daemon
+sme-eval retrieve              query()                eval endpoint         /search /graph
+                                  |                        |                     |
+   |-- question ---------------> |                        |                     |
+   |                              |-- POST  ------------> |                     |
+   |                              |   {query,             |-- /search?kind=...->|
+   |                              |    mock=True,         |<-- results ---------|
+   |                              |    limit=5}           |  rerank+decay+      |
+   |                              |                        |  compress+grounding|
+   |                              |<-- {answer (stub),  --|                     |
+   |                              |      context_string,                        |
+   |                              |      retrieved_entities,                    |
+   |                              |      retrieved_edges,                       |
+   |                              |      warnings, error}                       |
+   |                              |  deserialize+map                             |
+   |<-- QueryResult ------------- |                                              |
+   |                                                                              |
+   |-- question N ------------>  ... (no batching; one HTTP call per question)
+```
+
+`mock=true` is the default. Cat 1 scoring is deterministic under it because
+no LLM runs. The retrieval pipeline (rerank, decay, compress) is fully
+deterministic given the same palace state.
+
+## Error handling matrix
+
+| condition | adapter behavior |
+|---|---|
+| HTTP 4xx/5xx from familiar-api | `QueryResult(error=f"familiar endpoint {status}: {body[:200]}", context_string="", retrieved_entities=[], retrieved_edges=[])` |
+| Network timeout (`timeout_s`) | `QueryResult(error=f"familiar timeout after {timeout_s}s", ...)` |
+| Connection refused / DNS | `QueryResult(error=f"familiar connection failed: {e}", ...)` |
+| Response body not valid JSON | `QueryResult(error="familiar: invalid JSON response", ...)` |
+| `error` field non-null in response | Pass through verbatim |
+| `warnings` array contains `palace_unreachable` | Treat as adapter-level error; set `error = "WARN: palace_unreachable; ..."` |
+| `warnings` array contains `low_confidence` / `filtered_null_text_*` / `stuck_loop` | Append `WARN: <list>` to `error` (warnings AND data — not fatal) |
+| `get_graph_snapshot()` HTTP failure | Return `([], [])` + log warning |
+| Auth failure (palace key wrong/expired upstream) | Familiar returns 502 + structured error; pass through |
+| Adapter init: invalid `base_url` | `ValueError` at construction time, not at first query |
+
+**No retries.** SME runs are reproducible only when each query is one shot.
+If reproducibility wants retry, multipass core adds it — adapters don't.
+
+## Testing
+
+Mirror `tests/adapters/test_mempalace_daemon_adapter.py` structure:
+
+### `tests/adapters/test_familiar_adapter.py` — unit (mocked HTTP)
+
+- `test_query_happy_path` — `fake_urlopen_factory` returns SME-shape JSON;
+  verify deserialize result has all fields populated correctly.
+- `test_query_propagates_warnings` — warnings array becomes `error` field with
+  `WARN:` prefix; `retrieved_entities` still populated (warning is soft).
+- `test_query_palace_unreachable_is_hard_error` — when `warnings` contains
+  `palace_unreachable`, error reflects it; result is "errored", not
+  "answered wrong".
+- `test_query_http_4xx` — status code surfaced in error string.
+- `test_query_http_5xx` — same.
+- `test_query_timeout` — error string format.
+- `test_query_invalid_json` — error contract.
+- `test_query_default_mock_inference_is_true` — Cat 1 determinism guarantee.
+- `test_query_explicit_mock_false_passes_through` — for future Cat 9 work.
+- `test_get_graph_snapshot_maps_palace_graph` — JSON to Entity/Edge mapping;
+  reuses the shared mapping helpers (test directly against the shared
+  module rather than re-asserting in both adapters).
+- `test_get_graph_snapshot_failure_returns_empty` — error contract.
+- `test_ingest_corpus_is_noop` — returns expected stub.
+- `test_get_harness_manifest_returns_two_descriptors` — gated by
+  `HarnessDescriptor` importability.
+
+### `tests/adapters/test_familiar_live.py` — gated live smoke
+
+- `@pytest.mark.skipif(os.environ.get("FAMILIAR_BASE_URL") is None, ...)`
+- One `query()` against the actual deployed instance with a known-recall
+  question (e.g. "what realm projects exist"). Asserts non-empty
+  `retrieved_entities` (or graceful skip if palace HNSW is rebuilding).
+- One `get_graph_snapshot()`. Asserts non-empty entities + edges.
+
+Same pattern as `MemPalaceDaemonAdapter`'s gated live test.
+
+### Reuse `fake_urlopen_factory`
+
+The fixture `tests/adapters/fake_urlopen_factory.py` was added with the
+daemon adapter (commit `2376900`). Reuse it for familiar adapter mocking.
+
+## Open questions
+
+1. **Should the adapter expose `?trace=1` data in `QueryResult`?**
+   `/v1/chat/completions?trace=1` returns a richer Trace including
+   `inference_endpoint`, `duration_ms`, and `citations`. For Cat 1
+   (`mock=true`, no chat path), this is unavailable. For future Cat 9
+   inference-mode runs, the adapter could call `/v1/chat/completions?trace=1`
+   instead of the eval endpoint to capture per-turn telemetry. **Decision
+   for this spec:** out of scope. Cat 1 runs through the eval endpoint;
+   when Cat 9 ships, an inference-mode flag on the adapter will switch to
+   the chat path. Spec the seam, defer the implementation.
+2. **Should the adapter expose familiar's `inference_endpoint` field
+   (which provider served the response)?** Not in the v0.2 SmeEntity shape;
+   would need a separate trace fetch. Skip for v1 of the adapter; revisit
+   when Cat 9 needs per-model sensitivity (9e).
+3. **Should `mock=true`/`mock=false` be an SME-CLI flag rather than a
+   constructor arg?** Both. CLI flag overrides constructor default.
+   Convention: `--mock` / `--no-mock`, default `--mock`.
+
+## Acceptance criteria
+
+- `from sme.adapters.familiar import FamiliarAdapter` succeeds.
+- `pytest tests/adapters/test_familiar_adapter.py` — all green.
+- `pytest tests/adapters/test_familiar_live.py` skips cleanly when
+  `FAMILIAR_BASE_URL` is unset; passes when set against a healthy familiar.
+- `sme-eval retrieve --adapter familiar --base-url http://familiar:8080
+  --questions corpora/standard_v0_1/questions.yaml --json /tmp/run.json`
+  produces a non-empty per-question JSON output.
+- README adapter table includes familiar with the same row schema as
+  mempalace-daemon.
+
+## Implementation outline (for the plan)
+
+1. Extract `MemPalaceDaemonAdapter`'s `/graph` mapping into
+   `sme/adapters/_mempalace_graph.py`. Shared between daemon + familiar.
+2. Scaffold `sme/adapters/familiar.py` with class skeleton + constructor
+   + reuse of fake_urlopen_factory.
+3. Implement `query()` with happy path; tests.
+4. Implement error handling for 4xx/5xx/timeout/JSON-malformed; tests.
+5. Implement `warnings` translation rules (hard vs soft signals); tests.
+6. Implement `get_graph_snapshot()` via the shared module; tests.
+7. Implement `get_flat_retrieval()`, `get_ontology_source()`,
+   `get_harness_manifest()`; tests for each.
+8. Wire `--adapter familiar` and `--mock`/`--no-mock` flags in `cli.py`.
+9. Live smoke test (gated); README + ideas.md updates.
+10. PR.
+
+Plan will follow this in `docs/superpowers/plans/2026-04-26-familiar-adapter.md`.

--- a/sme/adapters/_graph_mapping.py
+++ b/sme/adapters/_graph_mapping.py
@@ -1,0 +1,139 @@
+"""Shared /graph payload to (Entity, Edge) mapping.
+
+palace-daemon's GET /graph returns a single payload shape (wings,
+rooms, tunnels, kg_entities, kg_triples, kg_stats). Both the
+MemPalaceDaemonAdapter and the FamiliarAdapter consume this shape.
+Familiar's GET /api/familiar/graph proxies the daemon's response
+unchanged (with a 5-minute cache), so both adapters share this
+projection function rather than re-implementing it.
+
+Extracted verbatim from MemPalaceDaemonAdapter._project_graph 2026-04-26.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from sme.adapters.base import Edge, Entity
+
+
+def project_graph(body: dict[str, Any]) -> tuple[list[Entity], list[Edge]]:
+    """Turn the daemon's /graph response into (entities, edges).
+
+    Mirrors the wing/room/tunnel projection in
+    ``sme.adapters.mempalace.MemPalaceAdapter.get_graph_snapshot``,
+    minus drawer-level surface (impractical at 151K-drawer scale
+    through the HTTP API).
+    """
+    wings: dict[str, int] = body.get("wings") or {}
+    rooms_by_wing: list[dict] = body.get("rooms") or []
+    tunnels: list[dict] = body.get("tunnels") or []
+    kg_ents: list[dict] = body.get("kg_entities") or []
+    kg_trips: list[dict] = body.get("kg_triples") or []
+
+    entities: list[Entity] = []
+    edges: list[Edge] = []
+
+    # Wings
+    for wing in sorted(wings):
+        entities.append(
+            Entity(
+                id=f"wing:{wing}",
+                name=wing,
+                entity_type="wing",
+                properties={"_table": "wing", "drawer_count": wings[wing]},
+            )
+        )
+
+    # Rooms — collect wings-per-room across the per-wing lists
+    room_wings: dict[str, set[str]] = defaultdict(set)
+    room_count: dict[str, int] = defaultdict(int)
+    for entry in rooms_by_wing:
+        wing = entry.get("wing", "")
+        for room, n in (entry.get("rooms") or {}).items():
+            if not room or room == "general":
+                continue
+            room_wings[room].add(wing)
+            room_count[room] += int(n or 0)
+
+    for room in sorted(room_wings):
+        wings_list = sorted(room_wings[room])
+        entities.append(
+            Entity(
+                id=f"room:{room}",
+                name=room,
+                entity_type="room:untyped",
+                properties={
+                    "_table": "room",
+                    "wings": wings_list,
+                    "drawer_count": room_count[room],
+                },
+            )
+        )
+        for wing in wings_list:
+            edges.append(
+                Edge(
+                    source_id=f"room:{room}",
+                    target_id=f"wing:{wing}",
+                    edge_type="member_of",
+                    properties={
+                        "_table": "structural",
+                        "drawer_count": room_count[room],
+                    },
+                )
+            )
+
+    # Tunnels — wing<->wing for each shared room
+    for t in tunnels:
+        room = t.get("room", "")
+        t_wings = sorted(t.get("wings") or [])
+        for i, wa in enumerate(t_wings):
+            for wb in t_wings[i + 1:]:
+                edges.append(
+                    Edge(
+                        source_id=f"wing:{wa}",
+                        target_id=f"wing:{wb}",
+                        edge_type="tunnel",
+                        properties={
+                            "_table": "structural",
+                            "via_room": room,
+                        },
+                    )
+                )
+
+    # KG layer
+    for ke in kg_ents:
+        ent_id = ke.get("id")
+        if not ent_id:
+            continue
+        props = dict(ke.get("properties") or {})
+        props["_table"] = "kg_entity"
+        entities.append(
+            Entity(
+                id=f"kg:{ent_id}",
+                name=ke.get("name") or ent_id,
+                entity_type=f"kg:{ke.get('type') or 'unknown'}",
+                properties=props,
+            )
+        )
+    for tr in kg_trips:
+        subj, obj = tr.get("subject"), tr.get("object")
+        if not subj or not obj:
+            continue
+        edges.append(
+            Edge(
+                source_id=f"kg:{subj}",
+                target_id=f"kg:{obj}",
+                edge_type=tr.get("predicate") or "kg_related",
+                properties={
+                    "_table": "kg_triple",
+                    "_created_at": tr.get("valid_from"),
+                    "valid_to": tr.get("valid_to"),
+                    "confidence": tr.get("confidence"),
+                    "source_file": tr.get("source_file"),
+                },
+            )
+        )
+
+    return entities, edges

--- a/sme/adapters/familiar.py
+++ b/sme/adapters/familiar.py
@@ -35,6 +35,11 @@ log = logging.getLogger(__name__)
 DEFAULT_BASE_URL = "http://familiar:8080"
 DEFAULT_TIMEOUT_S = 30.0
 
+# Soft warnings (low_confidence, filtered_null_text_*, stuck_loop) and hard
+# warnings (palace_unreachable) both surface in QueryResult.error with a
+# WARN: prefix; the distinction lives in the surfaced message text.
+HARD_WARNING_TOKENS = ("palace_unreachable",)
+
 
 class FamiliarAdapter(SMEAdapter):
     """Adapter for a running familiar.realm.watch v0.2.0+ instance."""
@@ -49,8 +54,6 @@ class FamiliarAdapter(SMEAdapter):
         self.base_url = base_url.rstrip("/")
         self.timeout_s = timeout_s
         self.mock_inference = mock_inference
-        # `opener` is injected by tests via fake_urlopen_factory; production
-        # code uses urllib.request.urlopen directly.
         self._opener = opener
 
     # --- Required SMEAdapter methods ---
@@ -70,7 +73,121 @@ class FamiliarAdapter(SMEAdapter):
         }
 
     def query(self, question: str) -> QueryResult:
-        raise NotImplementedError("Task 4-7")
+        """POST /api/familiar/eval and deserialize the SME-shape response."""
+        body = {
+            "query": question[:250],
+            "limit": 5,
+            "kind": "content",
+            "mock": self.mock_inference,
+        }
+        status, payload = self._post_json("/api/familiar/eval", body)
+        if status == -1:
+            msg = payload.get("_network_error", "unknown network error") if isinstance(payload, dict) else "unknown error"
+            return QueryResult(
+                answer="",
+                context_string="",
+                retrieved_entities=[],
+                retrieved_edges=[],
+                error=f"familiar {msg}",
+            )
+        if status != 200:
+            snippet = json.dumps(payload)[:200] if isinstance(payload, dict) else str(payload)[:200]
+            return QueryResult(
+                answer="",
+                context_string="",
+                retrieved_entities=[],
+                retrieved_edges=[],
+                error=f"familiar endpoint {status}: {snippet}",
+            )
+        return self._deserialize_query(payload)
 
     def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
-        raise NotImplementedError("Task 8")
+        raise NotImplementedError("Task 7")
+
+    # --- Internals ---
+
+    def _deserialize_query(self, payload: dict) -> QueryResult:
+        """Map familiar's JSON response onto SME QueryResult."""
+        answer = payload.get("answer") or ""
+        context_string = payload.get("context_string") or ""
+        raw_entities = payload.get("retrieved_entities") or []
+        raw_edges = payload.get("retrieved_edges") or []
+        server_error = payload.get("error")
+        warnings = payload.get("warnings") or []
+
+        entities = [self._entity_from_payload(e) for e in raw_entities]
+        edges = [self._edge_from_payload(e) for e in raw_edges]
+
+        parts: list[str] = []
+        if server_error:
+            parts.append(str(server_error))
+        if warnings:
+            parts.append("WARN: " + "; ".join(warnings))
+        error = " | ".join(parts) if parts else None
+
+        return QueryResult(
+            answer=answer,
+            context_string=context_string,
+            retrieved_entities=entities,
+            retrieved_edges=edges,
+            error=error,
+        )
+
+    @staticmethod
+    def _entity_from_payload(p: dict) -> Entity:
+        """Map a familiar SmeEntity dict to an SME Entity dataclass."""
+        eid = p.get("id") or ""
+        return Entity(
+            id=eid,
+            name=eid,
+            entity_type=p.get("type") or "drawer",
+            properties={
+                k: v for k, v in p.items() if k not in ("id", "type") and v is not None
+            },
+        )
+
+    @staticmethod
+    def _edge_from_payload(p: dict) -> Edge:
+        return Edge(
+            source_id=p.get("subject") or "",
+            target_id=p.get("object") or "",
+            edge_type=p.get("predicate") or "",
+        )
+
+    def _post_json(self, path: str, body: dict) -> tuple[int, Any]:
+        """POST JSON, return (status, parsed_body). Translates network and
+        JSON-decode failures into a sentinel (-1 status, error-bearing dict)
+        so the adapter's error contract stays no-raise."""
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        opener = self._opener or urllib.request.urlopen
+        try:
+            with opener(req, timeout=self.timeout_s) as resp:
+                raw = resp.read().decode("utf-8")
+                status = resp.status if hasattr(resp, "status") else resp.getcode()
+                try:
+                    parsed = json.loads(raw) if raw else {}
+                except json.JSONDecodeError as e:
+                    return -1, {"_network_error": f"invalid JSON response: {e}"}
+                return status, parsed
+        except urllib.error.HTTPError as e:
+            try:
+                raw = e.read().decode("utf-8", errors="replace")
+                try:
+                    return e.code, json.loads(raw)
+                except json.JSONDecodeError:
+                    return e.code, {"_raw": raw[:200]}
+            except Exception:
+                return e.code, {"_raw": ""}
+        except (socket.timeout, TimeoutError) as e:
+            return -1, {"_network_error": f"timeout after {self.timeout_s}s ({e})"}
+        except urllib.error.URLError as e:
+            return -1, {"_network_error": f"connection failed: {e.reason}"}
+        except Exception as e:
+            return -1, {"_network_error": f"unexpected: {type(e).__name__}: {e}"}

--- a/sme/adapters/familiar.py
+++ b/sme/adapters/familiar.py
@@ -102,7 +102,64 @@ class FamiliarAdapter(SMEAdapter):
         return self._deserialize_query(payload)
 
     def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
-        raise NotImplementedError("Task 7")
+        """GET /api/familiar/graph (familiar's proxy of palace-daemon
+        /graph) and project to (entities, edges) via the shared mapping
+        module. Failure returns ([], []) per the SME contract — a missing
+        snapshot zeroes out structural-category scores rather than
+        raising."""
+        status, body = self._get_json("/api/familiar/graph")
+        if status != 200 or not isinstance(body, dict) or "wings" not in body:
+            return [], []
+        return project_graph(body)
+
+    # --- Optional SMEAdapter methods ---
+
+    def get_flat_retrieval(self, question: str, k: int = 5) -> list[Entity]:
+        """Optional: same path as query() but returns only the entities,
+        used by Cat 7 token-budget analysis where the answer text is
+        irrelevant and only retrieval changes."""
+        body = {
+            "query": question[:250],
+            "limit": k,
+            "kind": "content",
+            "mock": self.mock_inference,
+        }
+        status, payload = self._post_json("/api/familiar/eval", body)
+        if status != 200 or not isinstance(payload, dict):
+            return []
+        raw_entities = payload.get("retrieved_entities") or []
+        return [self._entity_from_payload(e) for e in raw_entities]
+
+    def get_ontology_source(self) -> str:
+        """Wings/rooms taxonomy is author-declared (mempalace_get_taxonomy
+        MCP tool), not inferred from data. Same semantics as
+        MemPalaceDaemonAdapter."""
+        return "declared"
+
+    def get_harness_manifest(self) -> list:
+        """Forward-compat for SME Cat 9 (Handshake). Returns descriptors of
+        familiar's invocation surfaces — HTTP tool-call + MCP. Falls back
+        to [] when the multipass-side descriptor types aren't yet
+        importable (Cat 9 not implemented yet on this multipass version)."""
+        try:
+            from sme.harness import ToolCall, MCPResource  # type: ignore
+        except ImportError:
+            return []
+        return [
+            ToolCall(
+                name="familiar_query",
+                json_schema={
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                backend_endpoint=f"{self.base_url}/api/familiar/eval",
+            ),
+            MCPResource(
+                server_url=f"{self.base_url}/mcp",
+                resource_uri_pattern="familiar_(recall|reflect|chat)",
+            ),
+        ]
 
     # --- Internals ---
 
@@ -175,6 +232,36 @@ class FamiliarAdapter(SMEAdapter):
                     parsed = json.loads(raw) if raw else {}
                 except json.JSONDecodeError as e:
                     return -1, {"_network_error": f"invalid JSON response: {e}"}
+                return status, parsed
+        except urllib.error.HTTPError as e:
+            try:
+                raw = e.read().decode("utf-8", errors="replace")
+                try:
+                    return e.code, json.loads(raw)
+                except json.JSONDecodeError:
+                    return e.code, {"_raw": raw[:200]}
+            except Exception:
+                return e.code, {"_raw": ""}
+        except (socket.timeout, TimeoutError) as e:
+            return -1, {"_network_error": f"timeout after {self.timeout_s}s ({e})"}
+        except urllib.error.URLError as e:
+            return -1, {"_network_error": f"connection failed: {e.reason}"}
+        except Exception as e:
+            return -1, {"_network_error": f"unexpected: {type(e).__name__}: {e}"}
+
+    def _get_json(self, path: str) -> tuple[int, Any]:
+        """GET JSON, mirror _post_json's no-raise contract."""
+        url = f"{self.base_url}{path}"
+        req = urllib.request.Request(url, method="GET")
+        opener = self._opener or urllib.request.urlopen
+        try:
+            with opener(req, timeout=self.timeout_s) as resp:
+                raw = resp.read().decode("utf-8")
+                status = resp.status if hasattr(resp, "status") else resp.getcode()
+                try:
+                    parsed = json.loads(raw) if raw else {}
+                except json.JSONDecodeError as e:
+                    return -1, {"_network_error": f"invalid JSON: {e}"}
                 return status, parsed
         except urllib.error.HTTPError as e:
             try:

--- a/sme/adapters/familiar.py
+++ b/sme/adapters/familiar.py
@@ -1,0 +1,76 @@
+"""FamiliarAdapter — SME adapter for familiar.realm.watch v0.2.0+.
+
+Familiar wraps palace-daemon with a v0.2 retrieval pipeline (rerank,
+temporal decay, extractive compression, grounding directives). This
+adapter measures familiar's full pipeline; the sibling
+MemPalaceDaemonAdapter measures palace alone. Comparing their SME
+scores quantifies what familiar's v0.2 contributes.
+
+POST /api/familiar/eval already returns SME-QueryResult shape natively
+(familiar's chunk-C of v0.2 was designed against this contract), so the
+adapter is mostly deserialization with error/warning translation rules.
+GET /api/familiar/graph proxies palace-daemon's /graph; reuse the
+shared mapping module.
+
+Defaults to mock_inference=True so Cat 1 substring scoring stays
+deterministic — no LLM in the loop. Inference-mode runs are reserved
+for a future Cat 9 pass.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Optional
+
+from sme.adapters._graph_mapping import project_graph
+from sme.adapters.base import Edge, Entity, QueryResult, SMEAdapter
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_BASE_URL = "http://familiar:8080"
+DEFAULT_TIMEOUT_S = 30.0
+
+
+class FamiliarAdapter(SMEAdapter):
+    """Adapter for a running familiar.realm.watch v0.2.0+ instance."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+        mock_inference: bool = True,
+        opener: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_s = timeout_s
+        self.mock_inference = mock_inference
+        # `opener` is injected by tests via fake_urlopen_factory; production
+        # code uses urllib.request.urlopen directly.
+        self._opener = opener
+
+    # --- Required SMEAdapter methods ---
+
+    def ingest_corpus(self, corpus: list[dict]) -> dict:
+        """No-op stub. Familiar reads palace data it didn't author;
+        ingestion happens upstream via `mempalace mine`."""
+        return {
+            "entities_created": 0,
+            "edges_created": 0,
+            "errors": [],
+            "warnings": [
+                "FamiliarAdapter is diagnostic-only (Mode B). Familiar reads "
+                "palace data it didn't author; ingestion happens upstream via "
+                "`mempalace mine`. ingest_corpus is a no-op."
+            ],
+        }
+
+    def query(self, question: str) -> QueryResult:
+        raise NotImplementedError("Task 4-7")
+
+    def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
+        raise NotImplementedError("Task 8")

--- a/sme/adapters/familiar.py
+++ b/sme/adapters/familiar.py
@@ -72,11 +72,11 @@ class FamiliarAdapter(SMEAdapter):
             ],
         }
 
-    def query(self, question: str) -> QueryResult:
+    def query(self, question: str, n_results: int = 5) -> QueryResult:
         """POST /api/familiar/eval and deserialize the SME-shape response."""
         body = {
             "query": question[:250],
-            "limit": 5,
+            "limit": n_results,
             "kind": "content",
             "mock": self.mock_inference,
         }
@@ -114,7 +114,7 @@ class FamiliarAdapter(SMEAdapter):
 
     # --- Optional SMEAdapter methods ---
 
-    def get_flat_retrieval(self, question: str, k: int = 5) -> list[Entity]:
+    def get_flat_retrieval(self, question: str, k: int = 5) -> QueryResult:
         """Optional: same path as query() but returns only the entities,
         used by Cat 7 token-budget analysis where the answer text is
         irrelevant and only retrieval changes."""
@@ -126,15 +126,51 @@ class FamiliarAdapter(SMEAdapter):
         }
         status, payload = self._post_json("/api/familiar/eval", body)
         if status != 200 or not isinstance(payload, dict):
-            return []
+            return QueryResult(
+                answer="",
+                context_string="",
+                retrieved_entities=[],
+                retrieved_edges=[],
+                error=f"familiar flat-retrieval {status}",
+            )
         raw_entities = payload.get("retrieved_entities") or []
-        return [self._entity_from_payload(e) for e in raw_entities]
+        return QueryResult(
+            answer="",
+            context_string="",
+            retrieved_entities=[self._entity_from_payload(e) for e in raw_entities],
+            retrieved_edges=[],
+        )
 
-    def get_ontology_source(self) -> str:
+    def get_ontology_source(self) -> dict:
         """Wings/rooms taxonomy is author-declared (mempalace_get_taxonomy
-        MCP tool), not inferred from data. Same semantics as
-        MemPalaceDaemonAdapter."""
-        return "declared"
+        MCP tool). Same documented schema as the underlying MemPalace
+        install — we proxy the same palace through familiar's pipeline
+        without changing the ontology shape."""
+        return {
+            "type": "declared",
+            "schema": [
+                {
+                    "kind": "structural",
+                    "entities": [
+                        "wing", "room", "hall", "tunnel", "closet", "drawer"
+                    ],
+                },
+                {
+                    "kind": "hall_vocabulary",
+                    "values": [
+                        "facts", "events", "discoveries",
+                        "preferences", "advice",
+                    ],
+                },
+            ],
+            "documentation": (
+                "Familiar wraps a MemPalace palace with a v0.2 retrieval "
+                "pipeline (rerank, temporal decay, extractive compression, "
+                "grounding directives). The underlying ontology is "
+                "MemPalace's — Wings, Rooms, Halls, Tunnels, Closets, "
+                "Drawers."
+            ),
+        }
 
     def get_harness_manifest(self) -> list:
         """Forward-compat for SME Cat 9 (Handshake). Returns descriptors of

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from sme.adapters.base import Edge, Entity, QueryResult, SMEAdapter
+from sme.adapters._graph_mapping import project_graph
 
 log = logging.getLogger(__name__)
 
@@ -243,123 +244,11 @@ class MemPalaceDaemonAdapter(SMEAdapter):
 
     def _project_graph(self, body: dict) -> tuple[list[Entity], list[Edge]]:
         """Turn the daemon's /graph response into (entities, edges).
+        Delegates to the shared sme.adapters._graph_mapping module so
+        FamiliarAdapter (which proxies the same /graph response) can
+        reuse the identical projection."""
+        return project_graph(body)
 
-        Mirrors the wing/room/tunnel projection in
-        ``sme.adapters.mempalace.MemPalaceAdapter.get_graph_snapshot``,
-        minus drawer-level surface (impractical at 151K-drawer scale
-        through the HTTP API).
-        """
-        wings: dict[str, int] = body.get("wings") or {}
-        rooms_by_wing: list[dict] = body.get("rooms") or []
-        tunnels: list[dict] = body.get("tunnels") or []
-        kg_ents: list[dict] = body.get("kg_entities") or []
-        kg_trips: list[dict] = body.get("kg_triples") or []
-
-        entities: list[Entity] = []
-        edges: list[Edge] = []
-
-        # Wings
-        for wing in sorted(wings):
-            entities.append(
-                Entity(
-                    id=f"wing:{wing}",
-                    name=wing,
-                    entity_type="wing",
-                    properties={"_table": "wing", "drawer_count": wings[wing]},
-                )
-            )
-
-        # Rooms — collect wings-per-room across the per-wing lists
-        room_wings: dict[str, set[str]] = defaultdict(set)
-        room_count: dict[str, int] = defaultdict(int)
-        for entry in rooms_by_wing:
-            wing = entry.get("wing", "")
-            for room, n in (entry.get("rooms") or {}).items():
-                if not room or room == "general":
-                    continue
-                room_wings[room].add(wing)
-                room_count[room] += int(n or 0)
-
-        for room in sorted(room_wings):
-            wings_list = sorted(room_wings[room])
-            entities.append(
-                Entity(
-                    id=f"room:{room}",
-                    name=room,
-                    entity_type="room:untyped",
-                    properties={
-                        "_table": "room",
-                        "wings": wings_list,
-                        "drawer_count": room_count[room],
-                    },
-                )
-            )
-            for wing in wings_list:
-                edges.append(
-                    Edge(
-                        source_id=f"room:{room}",
-                        target_id=f"wing:{wing}",
-                        edge_type="member_of",
-                        properties={
-                            "_table": "structural",
-                            "drawer_count": room_count[room],
-                        },
-                    )
-                )
-
-        # Tunnels — wing<->wing for each shared room
-        for t in tunnels:
-            room = t.get("room", "")
-            t_wings = sorted(t.get("wings") or [])
-            for i, wa in enumerate(t_wings):
-                for wb in t_wings[i + 1:]:
-                    edges.append(
-                        Edge(
-                            source_id=f"wing:{wa}",
-                            target_id=f"wing:{wb}",
-                            edge_type="tunnel",
-                            properties={
-                                "_table": "structural",
-                                "via_room": room,
-                            },
-                        )
-                    )
-
-        # KG layer
-        for ke in kg_ents:
-            ent_id = ke.get("id")
-            if not ent_id:
-                continue
-            props = dict(ke.get("properties") or {})
-            props["_table"] = "kg_entity"
-            entities.append(
-                Entity(
-                    id=f"kg:{ent_id}",
-                    name=ke.get("name") or ent_id,
-                    entity_type=f"kg:{ke.get('type') or 'unknown'}",
-                    properties=props,
-                )
-            )
-        for tr in kg_trips:
-            subj, obj = tr.get("subject"), tr.get("object")
-            if not subj or not obj:
-                continue
-            edges.append(
-                Edge(
-                    source_id=f"kg:{subj}",
-                    target_id=f"kg:{obj}",
-                    edge_type=tr.get("predicate") or "kg_related",
-                    properties={
-                        "_table": "kg_triple",
-                        "_created_at": tr.get("valid_from"),
-                        "valid_to": tr.get("valid_to"),
-                        "confidence": tr.get("confidence"),
-                        "source_file": tr.get("source_file"),
-                    },
-                )
-            )
-
-        return entities, edges
 
     def _snapshot_via_mcp(self) -> tuple[list[Entity], list[Edge]]:
         """Walk the four MCP read tools and project to (entities, edges).

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -483,5 +483,37 @@ class MemPalaceDaemonAdapter(SMEAdapter):
                 answer="", context_string="", error=f"INTERNAL: {e}"
             )
 
+    def get_ontology_source(self) -> dict:
+        """Return the same MemPalace readme-derived ontology as the
+        direct ChromaDB adapter, so Cat 8 results are comparable across
+        the two access paths. The schema *as documented* doesn't change
+        because the backend access path does."""
+        return {
+            "type": "readme",
+            "schema": [
+                {
+                    "kind": "structural",
+                    "entities": [
+                        "wing", "room", "hall", "tunnel", "closet", "drawer"
+                    ],
+                },
+                {
+                    "kind": "hall_vocabulary",
+                    "values": [
+                        "facts", "events", "discoveries",
+                        "preferences", "advice",
+                    ],
+                },
+            ],
+            "documentation": (
+                "MemPalace organizes memories into Wings, Rooms, Halls, "
+                "Tunnels, Closets, and Drawers. See the existing "
+                "MemPalaceAdapter docstring for the full vocabulary. "
+                "This adapter accesses the palace via palace-daemon's "
+                "HTTP API rather than direct ChromaDB; the documented "
+                "ontology is unchanged."
+            ),
+        }
+
     def close(self) -> None:
         pass

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -26,7 +26,6 @@ import os
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections import defaultdict
 from pathlib import Path
 from typing import Any, Optional
 
@@ -50,7 +49,12 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     out: dict[str, str] = {}
     if not path.exists():
         return out
-    for line in path.read_text().splitlines():
+    try:
+        text = path.read_text()
+    except (OSError, UnicodeDecodeError) as e:
+        log.warning("env file %s unreadable (%s); falling back to env vars", path, e)
+        return out
+    for line in text.splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -143,11 +143,119 @@ class MemPalaceDaemonAdapter(SMEAdapter):
             "mempalace CLI directly."
         )
 
-    def query(self, question: str, **_kwargs: Any) -> QueryResult:
-        raise NotImplementedError("Implemented in a later task")
+    def query(
+        self,
+        question: str,
+        *,
+        n_results: int = 5,
+        kind: Optional[str] = None,
+        route: bool = False,  # accepted for CLI parity; daemon does its own
+        wing: Optional[str] = None,  # ignored; reserved for future expansion
+        room: Optional[str] = None,  # ignored; reserved for future expansion
+    ) -> QueryResult:
+        chosen_kind = kind or self.kind
+        params = urllib.parse.urlencode(
+            {"q": question, "limit": n_results, "kind": chosen_kind}
+        )
+        url = f"{self.api_url}/search?{params}"
+        body = self._http_get(url)
+        # body is a parsed dict here; errors are returned as QueryResult
+        if isinstance(body, QueryResult):
+            return body
+
+        results = body.get("results") or []
+        warnings = body.get("warnings") or []
+        total = body.get("total_before_filter")
+        available = body.get("available_in_scope")
+        retrieval_path = [
+            f"kind={chosen_kind}",
+            f"available_in_scope={available}",
+            f"total_before_filter={total}",
+        ]
+
+        if not results:
+            err = (
+                f"WARN: {'; '.join(warnings)}"
+                if warnings
+                else "NO_RESULTS"
+            )
+            return QueryResult(
+                answer="",
+                context_string="",
+                error=err,
+                retrieval_path=retrieval_path,
+            )
+
+        context_parts: list[str] = []
+        retrieved: list[Entity] = []
+        for i, hit in enumerate(results):
+            meta = hit.get("metadata") or {}
+            wing_name = meta.get("wing", "?")
+            room_name = meta.get("room", "?")
+            source_file = meta.get("source_file") or f"hit{i}"
+            source_label = Path(source_file).name or source_file
+            text = hit.get("text", "") or ""
+            context_parts.append(
+                f"[{i + 1}] [{wing_name}/{room_name}] {source_label}\n{text}"
+            )
+            retrieved.append(
+                Entity(
+                    id=f"drawer_hit:{i}",
+                    name=source_label,
+                    entity_type=f"drawer:{room_name}",
+                    properties={
+                        "_table": "mempalace_daemon_hit",
+                        "wing": wing_name,
+                        "room": room_name,
+                        "score": hit.get("score"),
+                        "source_file": source_file,
+                    },
+                )
+            )
+
+        context_string = "\n\n".join(context_parts)
+        warn_err = f"WARN: {'; '.join(warnings)}" if warnings else None
+        return QueryResult(
+            answer=context_string,
+            context_string=context_string,
+            retrieved_entities=retrieved,
+            retrieval_path=retrieval_path,
+            error=warn_err,
+        )
 
     def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
         raise NotImplementedError("Implemented in a later task")
+
+    # --- HTTP plumbing ------------------------------------------------
+
+    def _http_get(self, url: str) -> Any:
+        """GET ``url`` with X-API-Key, return parsed JSON or a QueryResult
+        wrapping the error. Used by both query() and snapshot calls.
+        """
+        req = urllib.request.Request(
+            url, method="GET", headers={"X-API-Key": self.api_key}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.api_timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            try:
+                detail = e.read().decode("utf-8", errors="replace")[:200]
+            except Exception:
+                detail = str(e)
+            if e.code in (401, 403):
+                err = f"AUTH: invalid X-API-Key ({e.code})"
+            else:
+                err = f"HTTP {e.code}: {detail}"
+            return QueryResult(answer="", context_string="", error=err)
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            return QueryResult(
+                answer="", context_string="", error=f"CONNECTION: {e}"
+            )
+        except Exception as e:  # pragma: no cover
+            return QueryResult(
+                answer="", context_string="", error=f"INTERNAL: {e}"
+            )
 
     def close(self) -> None:
         pass

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -1,0 +1,153 @@
+"""MemPalace daemon HTTP adapter for SME.
+
+Talks to a running palace-daemon (https://github.com/jphein/palace-daemon)
+over HTTP. Unlike sme.adapters.mempalace.MemPalaceAdapter (which opens
+ChromaDB directly), this adapter does NO filesystem access and holds NO
+parallel handles to the palace SQLite — it only makes HTTP requests.
+
+Use this adapter when:
+* you run palace-daemon (the daemon is the single writer to the palace),
+* OR you want SME's structural readings to flow through the same
+  retrieval path your production agents use.
+
+For single-process MemPalace installs without the daemon, the existing
+MemPalaceAdapter is correct — direct ChromaDB access is fine when there
+is no concurrent writer to fight with.
+
+See ``docs/superpowers/specs/2026-04-25-mempalace-daemon-adapter-design.md``
+for the full design.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Optional
+
+from sme.adapters.base import Edge, Entity, QueryResult, SMEAdapter
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_ENV_FILE = "~/.config/palace-daemon/env"
+DEFAULT_KIND = "content"
+DEFAULT_TIMEOUT = 180.0  # seconds — list_wings on a 151K-drawer palace ~30s
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Minimal KEY=VALUE parser. Strips surrounding double-quotes.
+
+    Ignores blank lines and ``# ...`` comments. Does NOT do shell expansion;
+    the daemon's env file is a flat key/value list, not a shell script.
+    """
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        if val and val[0] == val[-1] and val[0] in ('"', "'"):
+            val = val[1:-1]
+        out[key] = val
+    return out
+
+
+class MemPalaceDaemonAdapter(SMEAdapter):
+    """SMEAdapter against a running palace-daemon HTTP API.
+
+    Construction does not connect — auth is resolved eagerly but the first
+    network call happens in ``query()`` or ``get_graph_snapshot()``.
+
+    Args:
+        api_url: Daemon base URL (e.g. ``http://disks.jphe.in:8085``).
+            Trailing slash stripped.
+        api_key: Sent as ``X-API-Key`` header on every request.
+        env_file: Path to an env file with ``PALACE_DAEMON_URL`` /
+            ``PALACE_API_KEY``. Defaults to ``~/.config/palace-daemon/env``.
+        kind: Default ``kind`` filter for ``/search``. ``"content"``
+            (default) excludes Stop-hook auto-save checkpoints; pass
+            ``"all"`` to disable, ``"checkpoint"`` for snapshot-only.
+        api_timeout: Per-request HTTP timeout in seconds.
+        prefer_graph_endpoint: If True (default), ``get_graph_snapshot``
+            tries ``GET /graph`` first; on 404 it falls back to walking
+            the four MCP tools. Set False to force the MCP path.
+        read_only: Accepted for CLI parity. Ignored — this adapter only
+            reads via HTTP.
+        db_path: Accepted for CLI parity. Ignored — daemon owns the file.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        env_file: Optional[str | Path] = None,
+        kind: str = DEFAULT_KIND,
+        api_timeout: float = DEFAULT_TIMEOUT,
+        prefer_graph_endpoint: bool = True,
+        read_only: bool = True,
+        db_path: Optional[str] = None,
+    ) -> None:
+        self.kind = kind
+        self.api_timeout = api_timeout
+        self.prefer_graph_endpoint = prefer_graph_endpoint
+
+        env_path = Path(os.path.expanduser(str(env_file or DEFAULT_ENV_FILE)))
+        env_vars = _parse_env_file(env_path)
+
+        resolved_url = (
+            api_url
+            or env_vars.get("PALACE_DAEMON_URL")
+            or os.environ.get("PALACE_DAEMON_URL")
+        )
+        resolved_key = (
+            api_key
+            or env_vars.get("PALACE_API_KEY")
+            or os.environ.get("PALACE_API_KEY")
+        )
+
+        if not resolved_url:
+            raise ValueError(
+                "MemPalaceDaemonAdapter needs api_url. Pass it explicitly, "
+                f"set PALACE_DAEMON_URL in {env_path}, or export it in the "
+                "environment."
+            )
+        if not resolved_key:
+            raise ValueError(
+                "MemPalaceDaemonAdapter needs api_key. Pass it explicitly, "
+                f"set PALACE_API_KEY in {env_path}, or export it in the "
+                "environment."
+            )
+
+        self.api_url = resolved_url.rstrip("/")
+        self.api_key = resolved_key
+
+    # --- SMEAdapter required methods ---------------------------------
+
+    def ingest_corpus(self, corpus: list[dict]) -> dict:
+        raise NotImplementedError(
+            "MemPalaceDaemonAdapter is diagnostic-only (Mode B). To seed a "
+            "test palace, use the daemon's /memory POST endpoint or the "
+            "mempalace CLI directly."
+        )
+
+    def query(self, question: str, **_kwargs: Any) -> QueryResult:
+        raise NotImplementedError("Implemented in a later task")
+
+    def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
+        raise NotImplementedError("Implemented in a later task")
+
+    def close(self) -> None:
+        pass

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -224,7 +224,147 @@ class MemPalaceDaemonAdapter(SMEAdapter):
         )
 
     def get_graph_snapshot(self) -> tuple[list[Entity], list[Edge]]:
-        raise NotImplementedError("Implemented in a later task")
+        if self.prefer_graph_endpoint:
+            body = self._http_get(f"{self.api_url}/graph")
+            # _http_get returns QueryResult on error; treat 404 specifically
+            if isinstance(body, QueryResult):
+                if body.error and body.error.startswith("HTTP 404"):
+                    log.info(
+                        "/graph endpoint not present (404); falling back to MCP"
+                    )
+                else:
+                    log.warning(
+                        "/graph fetch failed: %s; falling back to MCP",
+                        body.error,
+                    )
+                return self._snapshot_via_mcp()
+            return self._project_graph(body)
+        return self._snapshot_via_mcp()
+
+    def _project_graph(self, body: dict) -> tuple[list[Entity], list[Edge]]:
+        """Turn the daemon's /graph response into (entities, edges).
+
+        Mirrors the wing/room/tunnel projection in
+        ``sme.adapters.mempalace.MemPalaceAdapter.get_graph_snapshot``,
+        minus drawer-level surface (impractical at 151K-drawer scale
+        through the HTTP API).
+        """
+        wings: dict[str, int] = body.get("wings") or {}
+        rooms_by_wing: list[dict] = body.get("rooms") or []
+        tunnels: list[dict] = body.get("tunnels") or []
+        kg_ents: list[dict] = body.get("kg_entities") or []
+        kg_trips: list[dict] = body.get("kg_triples") or []
+
+        entities: list[Entity] = []
+        edges: list[Edge] = []
+
+        # Wings
+        for wing in sorted(wings):
+            entities.append(
+                Entity(
+                    id=f"wing:{wing}",
+                    name=wing,
+                    entity_type="wing",
+                    properties={"_table": "wing", "drawer_count": wings[wing]},
+                )
+            )
+
+        # Rooms — collect wings-per-room across the per-wing lists
+        room_wings: dict[str, set[str]] = defaultdict(set)
+        room_count: dict[str, int] = defaultdict(int)
+        for entry in rooms_by_wing:
+            wing = entry.get("wing", "")
+            for room, n in (entry.get("rooms") or {}).items():
+                if not room or room == "general":
+                    continue
+                room_wings[room].add(wing)
+                room_count[room] += int(n or 0)
+
+        for room in sorted(room_wings):
+            wings_list = sorted(room_wings[room])
+            entities.append(
+                Entity(
+                    id=f"room:{room}",
+                    name=room,
+                    entity_type="room:untyped",
+                    properties={
+                        "_table": "room",
+                        "wings": wings_list,
+                        "drawer_count": room_count[room],
+                    },
+                )
+            )
+            for wing in wings_list:
+                edges.append(
+                    Edge(
+                        source_id=f"room:{room}",
+                        target_id=f"wing:{wing}",
+                        edge_type="member_of",
+                        properties={
+                            "_table": "structural",
+                            "drawer_count": room_count[room],
+                        },
+                    )
+                )
+
+        # Tunnels — wing<->wing for each shared room
+        for t in tunnels:
+            room = t.get("room", "")
+            t_wings = sorted(t.get("wings") or [])
+            for i, wa in enumerate(t_wings):
+                for wb in t_wings[i + 1:]:
+                    edges.append(
+                        Edge(
+                            source_id=f"wing:{wa}",
+                            target_id=f"wing:{wb}",
+                            edge_type="tunnel",
+                            properties={
+                                "_table": "structural",
+                                "via_room": room,
+                            },
+                        )
+                    )
+
+        # KG layer
+        for ke in kg_ents:
+            ent_id = ke.get("id")
+            if not ent_id:
+                continue
+            props = dict(ke.get("properties") or {})
+            props["_table"] = "kg_entity"
+            entities.append(
+                Entity(
+                    id=f"kg:{ent_id}",
+                    name=ke.get("name") or ent_id,
+                    entity_type=f"kg:{ke.get('type') or 'unknown'}",
+                    properties=props,
+                )
+            )
+        for tr in kg_trips:
+            subj, obj = tr.get("subject"), tr.get("object")
+            if not subj or not obj:
+                continue
+            edges.append(
+                Edge(
+                    source_id=f"kg:{subj}",
+                    target_id=f"kg:{obj}",
+                    edge_type=tr.get("predicate") or "kg_related",
+                    properties={
+                        "_table": "kg_triple",
+                        "_created_at": tr.get("valid_from"),
+                        "valid_to": tr.get("valid_to"),
+                        "confidence": tr.get("confidence"),
+                        "source_file": tr.get("source_file"),
+                    },
+                )
+            )
+
+        return entities, edges
+
+    def _snapshot_via_mcp(self) -> tuple[list[Entity], list[Edge]]:
+        """Stub — implemented in the next task."""
+        log.warning("MCP fallback path not yet implemented; returning empty")
+        return [], []
 
     # --- HTTP plumbing ------------------------------------------------
 

--- a/sme/adapters/mempalace_daemon.py
+++ b/sme/adapters/mempalace_daemon.py
@@ -362,9 +362,95 @@ class MemPalaceDaemonAdapter(SMEAdapter):
         return entities, edges
 
     def _snapshot_via_mcp(self) -> tuple[list[Entity], list[Edge]]:
-        """Stub — implemented in the next task."""
-        log.warning("MCP fallback path not yet implemented; returning empty")
-        return [], []
+        """Walk the four MCP read tools and project to (entities, edges).
+
+        Used when /graph is absent (older daemons) or when
+        ``prefer_graph_endpoint=False``.
+        """
+        wings_payload = self._mcp_call("mempalace_list_wings", {})
+        if wings_payload is None:
+            log.warning("list_wings failed; returning empty snapshot")
+            return [], []
+        wings: dict[str, int] = wings_payload.get("wings") or {}
+
+        # Per-wing list_rooms — sequential to match daemon-side rate limits;
+        # the daemon's MCP server runs each tool in its own asyncio task.
+        rooms_by_wing: list[dict] = []
+        for wing in sorted(wings):
+            rooms_payload = self._mcp_call(
+                "mempalace_list_rooms", {"wing": wing}
+            )
+            if rooms_payload is None:
+                log.warning("list_rooms(wing=%s) failed; skipping", wing)
+                continue
+            rooms_by_wing.append(rooms_payload)
+
+        tunnels_payload = self._mcp_call("mempalace_list_tunnels", {})
+        if tunnels_payload is None:
+            log.warning("list_tunnels failed; tunnels omitted from snapshot")
+            tunnels_payload = []
+        # The MCP tool returns a list directly — coerce to the /graph schema
+        # so _project_graph can consume it.
+        tunnels = (
+            tunnels_payload
+            if isinstance(tunnels_payload, list)
+            else tunnels_payload.get("tunnels", [])
+        )
+
+        synthesised = {
+            "wings": wings,
+            "rooms": rooms_by_wing,
+            "tunnels": tunnels,
+            "kg_entities": [],   # not reachable via MCP without arguments
+            "kg_triples": [],
+        }
+        return self._project_graph(synthesised)
+
+    def _mcp_call(self, tool: str, arguments: dict) -> Any:
+        """POST /mcp with a tools/call envelope. Returns the parsed
+        ``content[0].text`` JSON payload, or None on failure (logged).
+        """
+        rpc_body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.api_url}/mcp",
+            data=rpc_body,
+            method="POST",
+            headers={
+                "X-API-Key": self.api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.api_timeout) as resp:
+                envelope = json.loads(resp.read().decode("utf-8"))
+        except (
+            urllib.error.HTTPError,
+            urllib.error.URLError,
+            TimeoutError,
+            OSError,
+        ) as e:
+            log.warning("MCP %s failed: %s", tool, e)
+            return None
+        result = envelope.get("result") or {}
+        content = result.get("content") or []
+        if not content:
+            err = envelope.get("error")
+            if err:
+                log.warning("MCP %s returned error: %s", tool, err)
+            return None
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except Exception as e:  # pragma: no cover
+            log.warning("MCP %s returned non-JSON: %s (%s)", tool, text[:80], e)
+            return None
 
     # --- HTTP plumbing ------------------------------------------------
 

--- a/sme/cli.py
+++ b/sme/cli.py
@@ -916,6 +916,13 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
         adapter_kwargs["kind"] = args.kind
     if getattr(args, "query_mode", None):
         adapter_kwargs["default_query_mode"] = args.query_mode
+    # mock_inference is bool — explicit None means "use adapter default"
+    mock = getattr(args, "mock_inference", None)
+    if mock is not None:
+        adapter_kwargs["mock_inference"] = mock
+    timeout = getattr(args, "familiar_timeout", None)
+    if timeout is not None:
+        adapter_kwargs["timeout_s"] = timeout
     adapter = _load_adapter(args.adapter, **adapter_kwargs)
 
     # Run each question
@@ -1226,6 +1233,30 @@ def main(argv: list[str] | None = None) -> int:
         "--json",
         metavar="PATH",
         help="write full per-question results to this JSON path",
+    )
+    ret_mock = ret.add_mutually_exclusive_group()
+    ret_mock.add_argument(
+        "--mock",
+        dest="mock_inference",
+        action="store_true",
+        default=None,
+        help="(familiar) skip LLM inference, score retrieval only "
+        "(default: True for Cat 1 substring-scoring determinism).",
+    )
+    ret_mock.add_argument(
+        "--no-mock",
+        dest="mock_inference",
+        action="store_false",
+        help="(familiar) run inference; for future Cat 9 work where the "
+        "model writes the answer.",
+    )
+    ret.add_argument(
+        "--familiar-timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="(familiar) HTTP timeout for /api/familiar/eval and "
+        "/api/familiar/graph. Default 30s.",
     )
     ret.set_defaults(func=cmd_retrieve)
 

--- a/sme/cli.py
+++ b/sme/cli.py
@@ -1161,7 +1161,7 @@ def main(argv: list[str] | None = None) -> int:
     ret.add_argument(
         "--adapter",
         required=True,
-        help="adapter name (flat | mempalace | mempalace-daemon | ladybugdb)",
+        help="adapter name (flat | mempalace | mempalace-daemon | familiar | ladybugdb)",
     )
     ret.add_argument(
         "--db",
@@ -1174,7 +1174,7 @@ def main(argv: list[str] | None = None) -> int:
     ret.add_argument(
         "--api-url",
         metavar="URL",
-        help="(ladybugdb, mempalace-daemon) HTTP base URL for API-mode "
+        help="(ladybugdb, mempalace-daemon, familiar) HTTP base URL for API-mode "
         "queries (e.g. http://localhost:7720 for ladybugdb, or "
         "http://disks.jphe.in:8085 for mempalace-daemon).",
     )

--- a/sme/cli.py
+++ b/sme/cli.py
@@ -32,6 +32,23 @@ def _load_adapter(name: str, **kwargs) -> SMEAdapter:
 
         return LadybugDBAdapter(**kwargs)
 
+    if name in ("mempalace-daemon", "mempalace_daemon"):
+        from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+
+        # Drop kwargs the daemon adapter doesn't understand
+        for k in (
+            "include_node_tables",
+            "include_edge_tables",
+            "auto_discover",
+            "kg_path",
+            "collection_name",
+            "default_query_mode",
+            "db_path",
+            "buffer_pool_size",
+        ):
+            kwargs.pop(k, None)
+        return MemPalaceDaemonAdapter(**kwargs)
+
     if name == "mempalace":
         from sme.adapters.mempalace import MemPalaceAdapter
 
@@ -41,6 +58,8 @@ def _load_adapter(name: str, **kwargs) -> SMEAdapter:
             "include_edge_tables",
             "auto_discover",
             "api_url",
+            "api_key",
+            "kind",
             "default_query_mode",
         ):
             kwargs.pop(k, None)
@@ -55,6 +74,8 @@ def _load_adapter(name: str, **kwargs) -> SMEAdapter:
             "auto_discover",
             "kg_path",
             "api_url",
+            "api_key",
+            "kind",
             "default_query_mode",
         ):
             kwargs.pop(k, None)
@@ -448,6 +469,8 @@ def _load_adapter_from_args(args: argparse.Namespace) -> SMEAdapter:
         ("edge_tables", "include_edge_tables"),
         ("kg_path", "kg_path"),
         ("collection_name", "collection_name"),
+        ("api_key", "api_key"),
+        ("kind", "kind"),
     ):
         val = getattr(args, attr, None)
         if val:
@@ -472,9 +495,26 @@ def _add_db_or_api_args(parser: argparse.ArgumentParser) -> None:
         "--api-url",
         default=None,
         metavar="URL",
-        help="HTTP base URL for the graph's API (e.g. http://localhost:7740). "
-        "Enables graph-snapshot queries through the Cypher endpoint "
-        "instead of opening the .ldb file — works against locked DBs.",
+        help="HTTP base URL for the graph's API (e.g. http://localhost:7740 "
+        "for ladybugdb, or http://disks.jphe.in:8085 for the mempalace "
+        "daemon). Enables graph-snapshot queries through the API instead "
+        "of opening the file — works against locked or daemon-fronted DBs.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        metavar="KEY",
+        help="(mempalace-daemon) X-API-Key for the palace-daemon. "
+        "Defaults to PALACE_API_KEY in ~/.config/palace-daemon/env, "
+        "then to the process env var of the same name.",
+    )
+    parser.add_argument(
+        "--kind",
+        default=None,
+        metavar="KIND",
+        help="(mempalace-daemon) /search kind filter. Defaults to "
+        "'content' (excludes Stop-hook auto-save checkpoints). Use "
+        "'all' to disable, or 'checkpoint' for snapshot-only lookups.",
     )
 
 
@@ -816,6 +856,10 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
         adapter_kwargs["collection_name"] = args.collection_name
     if getattr(args, "api_url", None):
         adapter_kwargs["api_url"] = args.api_url
+    if getattr(args, "api_key", None):
+        adapter_kwargs["api_key"] = args.api_key
+    if getattr(args, "kind", None):
+        adapter_kwargs["kind"] = args.kind
     if getattr(args, "query_mode", None):
         adapter_kwargs["default_query_mode"] = args.query_mode
     adapter = _load_adapter(args.adapter, **adapter_kwargs)
@@ -1064,21 +1108,33 @@ def main(argv: list[str] | None = None) -> int:
     ret.add_argument(
         "--adapter",
         required=True,
-        help="adapter name (flat | mempalace | ladybugdb)",
+        help="adapter name (flat | mempalace | mempalace-daemon | ladybugdb)",
     )
     ret.add_argument(
         "--db",
         required=False,
         default=None,
         help="path passed to the adapter as db_path. Optional when "
-        "--api-url is supplied (ladybugdb adapter in API-only mode).",
+        "--api-url is supplied (ladybugdb adapter in API-only mode, or "
+        "the mempalace-daemon adapter which never takes a path).",
     )
     ret.add_argument(
         "--api-url",
         metavar="URL",
-        help="(ladybugdb) HTTP base URL for API-mode queries (e.g. "
-        "http://localhost:7720). Lets the adapter query a live server "
-        "without opening the local .ldb file (avoiding writer locks).",
+        help="(ladybugdb, mempalace-daemon) HTTP base URL for API-mode "
+        "queries (e.g. http://localhost:7720 for ladybugdb, or "
+        "http://disks.jphe.in:8085 for mempalace-daemon).",
+    )
+    ret.add_argument(
+        "--api-key",
+        metavar="KEY",
+        help="(mempalace-daemon) X-API-Key. Defaults to PALACE_API_KEY "
+        "in ~/.config/palace-daemon/env, then process env.",
+    )
+    ret.add_argument(
+        "--kind",
+        metavar="KIND",
+        help="(mempalace-daemon) /search kind filter. Default 'content'.",
     )
     ret.add_argument(
         "--query-mode",

--- a/sme/cli.py
+++ b/sme/cli.py
@@ -49,6 +49,28 @@ def _load_adapter(name: str, **kwargs) -> SMEAdapter:
             kwargs.pop(k, None)
         return MemPalaceDaemonAdapter(**kwargs)
 
+    if name == "familiar":
+        from sme.adapters.familiar import FamiliarAdapter
+
+        # Drop kwargs the familiar adapter doesn't understand
+        for k in (
+            "include_node_tables",
+            "include_edge_tables",
+            "auto_discover",
+            "kg_path",
+            "collection_name",
+            "default_query_mode",
+            "db_path",
+            "buffer_pool_size",
+            "api_key",
+            "kind",
+        ):
+            kwargs.pop(k, None)
+        # CLI uses --api-url; familiar adapter constructor uses base_url.
+        if "api_url" in kwargs:
+            kwargs["base_url"] = kwargs.pop("api_url")
+        return FamiliarAdapter(**kwargs)
+
     if name == "mempalace":
         from sme.adapters.mempalace import MemPalaceAdapter
 
@@ -475,6 +497,13 @@ def _load_adapter_from_args(args: argparse.Namespace) -> SMEAdapter:
         val = getattr(args, attr, None)
         if val:
             adapter_kwargs[key] = val
+    # mock_inference is bool — explicit None means "use adapter default"
+    mock = getattr(args, "mock_inference", None)
+    if mock is not None:
+        adapter_kwargs["mock_inference"] = mock
+    timeout = getattr(args, "familiar_timeout", None)
+    if timeout is not None:
+        adapter_kwargs["timeout_s"] = timeout
     return _load_adapter(args.adapter, **adapter_kwargs)
 
 
@@ -515,6 +544,30 @@ def _add_db_or_api_args(parser: argparse.ArgumentParser) -> None:
         help="(mempalace-daemon) /search kind filter. Defaults to "
         "'content' (excludes Stop-hook auto-save checkpoints). Use "
         "'all' to disable, or 'checkpoint' for snapshot-only lookups.",
+    )
+    mock_group = parser.add_mutually_exclusive_group()
+    mock_group.add_argument(
+        "--mock",
+        dest="mock_inference",
+        action="store_true",
+        default=None,
+        help="(familiar) skip LLM inference, score retrieval only "
+        "(default: True for Cat 1 substring-scoring determinism).",
+    )
+    mock_group.add_argument(
+        "--no-mock",
+        dest="mock_inference",
+        action="store_false",
+        help="(familiar) run inference; for future Cat 9 work where the "
+        "model writes the answer.",
+    )
+    parser.add_argument(
+        "--familiar-timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="(familiar) HTTP timeout for /api/familiar/eval and "
+        "/api/familiar/graph. Default 30s.",
     )
 
 

--- a/sme/cli.py
+++ b/sme/cli.py
@@ -64,6 +64,7 @@ def _load_adapter(name: str, **kwargs) -> SMEAdapter:
             "buffer_pool_size",
             "api_key",
             "kind",
+            "read_only",
         ):
             kwargs.pop(k, None)
         # CLI uses --api-url; familiar adapter constructor uses base_url.

--- a/sme/corpora/jp_realm_v0_1/questions.yaml
+++ b/sme/corpora/jp_realm_v0_1/questions.yaml
@@ -1,0 +1,244 @@
+# JP-realm baseline corpus — v0.1
+#
+# Questions probing JP's actual palace (~151K drawers as of 2026-04-26).
+# Mode B (diagnostic): no ingest step. Questions target content known to
+# exist in JP's palace based on session context, CLAUDE.md, and the
+# trace logs from familiar's pipeline 2026-04-25/26.
+#
+# `expected_sources` = substrings expected to appear in the adapter's
+# `context_string` if retrieval is working. Mix of drawer text, wing/
+# room labels, and topic keywords. Recall is fraction-of-expected
+# matched per question, summed across the run.
+#
+# Seed authored 2026-04-26 by Claude with JP. Expand over time as
+# retrieval failures surface gaps.
+
+version: jp-realm-v0.1
+description: |
+  Diagnostic corpus for JP's live palace via familiar v0.2 pipeline.
+  Compare familiar adapter scores vs mempalace_daemon adapter scores
+  on the same questions to measure what familiar's rerank/decay/compress/
+  grounding contributes on top of palace-daemon's recall.
+
+questions:
+  # --- Realm.watch ecosystem (5) ---
+
+  - id: q01_familiar_what
+    text: "What is familiar.realm.watch?"
+    expected_sources:
+      - familiar
+      - palace
+    min_hops: 1
+
+  - id: q02_realm_sigil_role
+    text: "What does realm-sigil do across JP's projects?"
+    expected_sources:
+      - sigil
+      - version
+    min_hops: 1
+
+  - id: q03_status_realm_watch
+    text: "What is status.realm.watch and what does it monitor?"
+    expected_sources:
+      - status
+      - realm
+    min_hops: 1
+
+  - id: q04_os_realm_watch
+    text: "What is os.realm.watch?"
+    expected_sources:
+      - "os.realm"
+      - quest
+    min_hops: 1
+
+  - id: q05_portal_realm
+    text: "What does the realm-portal VM serve?"
+    expected_sources:
+      - portal
+      - VM
+    min_hops: 1
+
+  # --- mempalace + palace-daemon (5) ---
+
+  - id: q06_mempalace_fork
+    text: "What are the key features of JP's mempalace fork vs upstream?"
+    expected_sources:
+      - mempalace
+      - fork
+    min_hops: 1
+
+  - id: q07_palace_daemon_role
+    text: "What is palace-daemon for?"
+    expected_sources:
+      - daemon
+      - HTTP
+    min_hops: 1
+
+  - id: q08_kind_filter
+    text: "What does the kind=content search filter do?"
+    expected_sources:
+      - kind
+      - checkpoint
+    min_hops: 1
+
+  - id: q09_silent_save
+    text: "What is the /silent-save endpoint?"
+    expected_sources:
+      - silent-save
+      - diary
+    min_hops: 1
+
+  - id: q10_hnsw_rebuild
+    text: "How do you rebuild the HNSW index when search recall is degraded?"
+    expected_sources:
+      - HNSW
+      - rebuild
+    min_hops: 1
+
+  # --- Forks JP has surveyed (5) ---
+
+  - id: q11_multipass_role
+    text: "What is multipass-structural-memory-eval?"
+    expected_sources:
+      - multipass
+      - eval
+    min_hops: 1
+
+  - id: q12_rlm_paper
+    text: "What is the rlm (Recursive Language Models) project about?"
+    expected_sources:
+      - rlm
+      - recursive
+    min_hops: 1
+
+  - id: q13_graphpalace
+    text: "What is GraphPalace and how does its pheromone model work?"
+    expected_sources:
+      - GraphPalace
+      - pheromone
+    min_hops: 1
+
+  - id: q14_hermes_agent
+    text: "What is hermes-agent?"
+    expected_sources:
+      - hermes
+      - agent
+    min_hops: 1
+
+  - id: q15_context_engine_emmimal
+    text: "What is the Emmimal context-engine framework?"
+    expected_sources:
+      - context-engine
+      - rerank
+    min_hops: 1
+
+  # --- Tools / workflow (5) ---
+
+  - id: q16_speech_to_cli
+    text: "What does speech-to-cli do?"
+    expected_sources:
+      - speech
+      - voice
+    min_hops: 1
+
+  - id: q17_vault_gate
+    text: "What is vault-gate and how does it unlock Vaultwarden?"
+    expected_sources:
+      - vault-gate
+      - bw
+    min_hops: 1
+
+  - id: q18_cc_switcher
+    text: "What is the cc tool used for?"
+    expected_sources:
+      - claude-code-switcher
+      - provider
+    min_hops: 1
+
+  - id: q19_outline_wiki
+    text: "What is JP's Outline wiki used for?"
+    expected_sources:
+      - outline
+      - documentation
+    min_hops: 1
+
+  - id: q20_realm_optimizer
+    text: "What is realm-optimizer?"
+    expected_sources:
+      - optimizer
+      - quest
+    min_hops: 1
+
+  # --- Infrastructure / homelab (5) ---
+
+  - id: q21_gatekeeper_router
+    text: "What is the gatekeeper firewall and what does it run?"
+    expected_sources:
+      - gatekeeper
+      - OpenWrt
+    min_hops: 1
+
+  - id: q22_ubox0_caddy
+    text: "What does ubox0 serve via Caddy?"
+    expected_sources:
+      - ubox0
+      - Caddy
+    min_hops: 1
+
+  - id: q23_disks_services
+    text: "What services run on the disks host?"
+    expected_sources:
+      - disks
+      - palace-daemon
+    min_hops: 2
+
+  - id: q24_katana_role
+    text: "What is the role of katana in JP's homelab?"
+    expected_sources:
+      - katana
+      - GPU
+    min_hops: 1
+
+  - id: q25_vlans_collectd
+    text: "How is JP's network organized in VLANs?"
+    expected_sources:
+      - VLAN
+      - collectd
+    min_hops: 2
+
+  # --- Specific incidents / decisions (5) ---
+
+  - id: q26_caddy_dns_resolvers
+    text: "What was the Caddy ACME DNS-01 cert renewal issue and the fix?"
+    expected_sources:
+      - resolvers
+      - dns-01
+    min_hops: 1
+
+  - id: q27_v02_retrieval_pipeline
+    text: "What does familiar v0.2's retrieval pipeline do?"
+    expected_sources:
+      - rerank
+      - decay
+    min_hops: 2
+
+  - id: q28_postgres_migration
+    text: "What is the planned palace storage migration to Postgres?"
+    expected_sources:
+      - Postgres
+      - pgvector
+    min_hops: 1
+
+  - id: q29_p40_upgrade
+    text: "What is the planned P40 GPU upgrade for the familiar host?"
+    expected_sources:
+      - P40
+      - VRAM
+    min_hops: 1
+
+  - id: q30_techempower
+    text: "What is JP's TechEmpower work?"
+    expected_sources:
+      - TechEmpower
+      - technology
+    min_hops: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import io
+import json
+
 import pytest
 
 from sme.topology.fixtures import synthetic_duplicates_graph, synthetic_gap_graph
@@ -26,11 +29,6 @@ def duplicates_graph():
     exact collisions seeded.
     """
     return synthetic_duplicates_graph()
-
-
-import io
-import json
-import urllib.error
 
 
 class _FakeResponse:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,87 @@ def duplicates_graph():
     exact collisions seeded.
     """
     return synthetic_duplicates_graph()
+
+
+import io
+import json
+import urllib.error
+
+
+class _FakeResponse:
+    """Minimal stand-in for urlopen()'s return value.
+
+    Mocks the context-manager + .read() shape that the adapter uses.
+    """
+
+    def __init__(self, body, status=200):
+        if isinstance(body, (dict, list)):
+            body = json.dumps(body)
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        self._buf = io.BytesIO(body)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._buf.read()
+
+
+@pytest.fixture
+def fake_urlopen_factory(monkeypatch):
+    """Build a fake urlopen that returns canned responses per URL.
+
+    Usage::
+
+        fake_urlopen_factory({
+            "GET http://daemon/search?q=hi&limit=5&kind=content": {"results": [...]},
+            "POST http://daemon/mcp": {"result": {"content": [...]}},
+        })
+
+    The key is ``"<METHOD> <full URL up to but not including any extra query>"``.
+    Match is by exact prefix on the URL — query strings are compared in full
+    when present in the key, otherwise the prefix wins.
+
+    A response value can be:
+    * dict/list — JSON-encoded as 200 OK
+    * str/bytes — sent as-is, 200 OK
+    * tuple ``(status, body)`` — explicit status
+    * Exception — raised when the URL is hit
+    * callable ``(req) -> response`` — invoked to dispatch on the request
+      body (used for JSON-RPC mocks)
+    """
+
+    def factory(routes):
+        def fake_urlopen(req, timeout=None):
+            method = req.get_method()
+            url = req.full_url
+            key_full = f"{method} {url}"
+            if key_full in routes:
+                resp = routes[key_full]
+            else:
+                base = url.split("?", 1)[0]
+                key_base = f"{method} {base}"
+                if key_base in routes:
+                    resp = routes[key_base]
+                else:
+                    raise AssertionError(f"unexpected request: {key_full}")
+            # If the registered response is a callable, invoke it with the
+            # request — used for body-dispatching mocks (e.g. JSON-RPC).
+            if callable(resp) and not isinstance(resp, Exception):
+                resp = resp(req)
+            if isinstance(resp, Exception):
+                raise resp
+            if isinstance(resp, tuple):
+                status, body = resp
+                return _FakeResponse(body, status=status)
+            return _FakeResponse(resp)
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        return fake_urlopen
+
+    return factory

--- a/tests/fixtures/tiny_questions.yaml
+++ b/tests/fixtures/tiny_questions.yaml
@@ -1,0 +1,10 @@
+version: "smoke-2026-04-25"
+questions:
+  - id: q1
+    text: "what is the structural memory evaluation framework"
+    expected_sources: []
+    min_hops: 0
+  - id: q2
+    text: "how does mempalace organize memories"
+    expected_sources: []
+    min_hops: 0

--- a/tests/test_familiar_adapter.py
+++ b/tests/test_familiar_adapter.py
@@ -241,3 +241,85 @@ def test_query_server_error_takes_precedence(fake_urlopen_factory):
     result = FamiliarAdapter().query("x")
     assert "explicit server error" in (result.error or "")
     assert "low_confidence" in (result.error or "")
+
+
+# --- Task 7: get_graph_snapshot ---
+
+def test_get_graph_snapshot_happy_path(fake_urlopen_factory):
+    body = {
+        "wings": {"realmwatch": 12, "personal": 7},
+        "rooms": [
+            {"wing": "realmwatch", "rooms": {"gatekeeper": 5}},
+            {"wing": "personal", "rooms": {"hobbies": 4}},
+        ],
+        "tunnels": [{"room": "tools", "wings": ["realmwatch", "personal"]}],
+        "kg_entities": [
+            {"id": "ent_1", "name": "JP", "type": "person", "properties": {}}
+        ],
+        "kg_triples": [
+            {"subject": "ent_1", "predicate": "owns", "object": "ent_repo"}
+        ],
+        "kg_stats": {"entities": 1, "triples": 1},
+    }
+    fake_urlopen_factory({GRAPH_ROUTE: body})
+    entities, edges = FamiliarAdapter().get_graph_snapshot()
+
+    wing_ids = [e.id for e in entities if e.entity_type == "wing"]
+    assert "wing:realmwatch" in wing_ids
+    assert "wing:personal" in wing_ids
+
+    kg_ids = [e.id for e in entities if e.entity_type.startswith("kg:")]
+    assert "kg:ent_1" in kg_ids
+
+    tunnel_edges = [e for e in edges if e.edge_type == "tunnel"]
+    assert any(
+        {edge.source_id, edge.target_id} == {"wing:realmwatch", "wing:personal"}
+        for edge in tunnel_edges
+    )
+
+
+def test_get_graph_snapshot_failure_returns_empty(fake_urlopen_factory):
+    fake_urlopen_factory({GRAPH_ROUTE: (502, {"error": "daemon down"})})
+    entities, edges = FamiliarAdapter().get_graph_snapshot()
+    assert entities == []
+    assert edges == []
+
+
+def test_get_graph_snapshot_missing_wings_returns_empty(fake_urlopen_factory):
+    """Defensive: empty/malformed body shouldn't crash project_graph."""
+    fake_urlopen_factory({GRAPH_ROUTE: {"unrelated": "shape"}})
+    entities, edges = FamiliarAdapter().get_graph_snapshot()
+    assert entities == []
+    assert edges == []
+
+
+# --- Task 8: optional methods ---
+
+def test_get_flat_retrieval_returns_entities_only(fake_urlopen_factory):
+    body = _ok_response_with_warnings([])
+    body["retrieved_entities"] = [
+        {"id": f"d{i}", "type": "drawer", "wing": "w", "room": "r"}
+        for i in range(3)
+    ]
+    fake_urlopen_factory({EVAL_ROUTE: body})
+    entities = FamiliarAdapter().get_flat_retrieval("test", k=3)
+    assert len(entities) == 3
+    assert all(e.entity_type == "drawer" for e in entities)
+
+
+def test_get_flat_retrieval_failure_returns_empty(fake_urlopen_factory):
+    fake_urlopen_factory({EVAL_ROUTE: (500, {"error": "x"})})
+    entities = FamiliarAdapter().get_flat_retrieval("test")
+    assert entities == []
+
+
+def test_get_ontology_source_returns_declared():
+    assert FamiliarAdapter().get_ontology_source() == "declared"
+
+
+def test_get_harness_manifest_returns_list():
+    """Forward-compat: returns [] if HarnessDescriptor types not importable
+    (current state); will return 2 descriptors once Cat 9 ships in multipass."""
+    manifest = FamiliarAdapter(base_url="https://familiar.jphe.in").get_harness_manifest()
+    assert isinstance(manifest, list)
+    assert len(manifest) in (0, 2)

--- a/tests/test_familiar_adapter.py
+++ b/tests/test_familiar_adapter.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-import json
 import socket
 import urllib.error
 
 import pytest
 
 from sme.adapters.familiar import FamiliarAdapter
+
+
+EVAL_ROUTE = "POST http://familiar:8080/api/familiar/eval"
+GRAPH_ROUTE = "GET http://familiar:8080/api/familiar/graph"
 
 
 # --- Task 2: instantiation ---
@@ -46,3 +49,195 @@ def test_ingest_corpus_is_noop():
     assert result["errors"] == []
     assert any("diagnostic-only" in w.lower() or "no-op" in w.lower()
                for w in result["warnings"])
+
+
+# --- Task 4: query happy path ---
+
+def test_query_happy_path(fake_urlopen_factory):
+    """Mocked POST returns SME-shape JSON; adapter deserializes."""
+    response_body = {
+        "answer": "(mock=true: inference skipped)",
+        "context_string": "── Palace context (1 drawer) ──\nUser enjoys hiking.",
+        "retrieved_entities": [
+            {
+                "id": "drawer_abc",
+                "type": "drawer",
+                "wing": "projects",
+                "room": "technical",
+                "topic": "hobbies",
+                "content_snippet": "User enjoys hiking.",
+                "cosine": 0.81,
+                "bm25": 0.42,
+                "matched_via": "drawer",
+                "provenance": {"kind": "observed"},
+            }
+        ],
+        "retrieved_edges": [],
+        "error": None,
+        "warnings": [],
+        "available_in_scope": 151478,
+    }
+    fake_urlopen_factory({EVAL_ROUTE: response_body})
+    adapter = FamiliarAdapter()
+
+    result = adapter.query("What are my hobbies?")
+
+    assert result.error is None
+    assert result.answer.startswith("(mock=true")
+    assert "User enjoys hiking" in result.context_string
+    assert len(result.retrieved_entities) == 1
+    e = result.retrieved_entities[0]
+    assert e.id == "drawer_abc"
+    assert e.entity_type == "drawer"
+    assert e.properties["wing"] == "projects"
+    assert e.properties["cosine"] == 0.81
+    assert result.retrieved_edges == []
+
+
+def test_query_default_mock_inference_is_true(fake_urlopen_factory, monkeypatch):
+    """Cat 1 determinism guarantee: default mock=true."""
+    captured = {}
+
+    def capture(routes):
+        original = routes
+        # Wrap default fake — capture the body before responding
+        return None  # not used; we do this inline below
+
+    # Use a custom opener to capture the request body
+    import json as _json
+
+    def custom_opener(req, timeout=None):
+        captured["body"] = _json.loads(req.data.decode())
+        class FakeResp:
+            status = 200
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+            def read(self): return _json.dumps({
+                "answer": "x", "context_string": "x",
+                "retrieved_entities": [], "retrieved_edges": [],
+                "error": None, "warnings": [],
+            }).encode()
+            def getcode(self): return 200
+        return FakeResp()
+
+    adapter = FamiliarAdapter(opener=custom_opener)
+    adapter.query("anything")
+    assert captured["body"]["mock"] is True
+    assert captured["body"]["kind"] == "content"
+
+
+def test_query_explicit_mock_false_passes_through(fake_urlopen_factory):
+    captured = {}
+    import json as _json
+
+    def custom_opener(req, timeout=None):
+        captured["body"] = _json.loads(req.data.decode())
+        class FakeResp:
+            status = 200
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+            def read(self): return b'{"answer":"","context_string":"","retrieved_entities":[],"retrieved_edges":[],"error":null,"warnings":[]}'
+            def getcode(self): return 200
+        return FakeResp()
+
+    adapter = FamiliarAdapter(opener=custom_opener, mock_inference=False)
+    adapter.query("anything")
+    assert captured["body"]["mock"] is False
+
+
+# --- Task 5: HTTP / network error contract ---
+
+def test_query_http_500(fake_urlopen_factory):
+    fake_urlopen_factory({EVAL_ROUTE: (500, {"error": "internal"})})
+    result = FamiliarAdapter().query("anything")
+    assert result.error is not None
+    assert "500" in result.error
+    assert result.retrieved_entities == []
+
+
+def test_query_http_400(fake_urlopen_factory):
+    fake_urlopen_factory({EVAL_ROUTE: (400, {"error": "bad json"})})
+    result = FamiliarAdapter().query("anything")
+    assert "400" in (result.error or "")
+
+
+def test_query_timeout():
+    def raising(*a, **kw):
+        raise socket.timeout("boom")
+    result = FamiliarAdapter(opener=raising, timeout_s=2.0).query("anything")
+    assert result.error is not None
+    assert "timeout" in result.error.lower() or "boom" in result.error
+
+
+def test_query_connection_refused():
+    def raising(*a, **kw):
+        raise urllib.error.URLError("Connection refused")
+    result = FamiliarAdapter(opener=raising).query("anything")
+    assert result.error is not None
+    assert "connection" in result.error.lower() or "refused" in result.error.lower()
+
+
+def test_query_invalid_json():
+    class BadJsonResp:
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def read(self): return b"not json at all"
+        def getcode(self): return 200
+    def opener(*a, **kw):
+        return BadJsonResp()
+    result = FamiliarAdapter(opener=opener).query("anything")
+    assert result.error is not None
+    assert "json" in result.error.lower()
+
+
+# --- Task 6: warnings translation ---
+
+def _ok_response_with_warnings(warnings):
+    return {
+        "answer": "x",
+        "context_string": "x",
+        "retrieved_entities": [
+            {"id": "drawer_x", "type": "drawer", "wing": "w",
+             "room": "r", "content_snippet": "x"}
+        ],
+        "retrieved_edges": [],
+        "error": None,
+        "warnings": warnings,
+    }
+
+
+def test_query_soft_warnings_become_warn_prefix(fake_urlopen_factory):
+    fake_urlopen_factory({
+        EVAL_ROUTE: _ok_response_with_warnings(["low_confidence", "filtered_null_text_1"])
+    })
+    result = FamiliarAdapter().query("x")
+    assert result.error is not None
+    assert "WARN" in result.error
+    assert "low_confidence" in result.error
+    assert "filtered_null_text_1" in result.error
+    assert len(result.retrieved_entities) == 1  # data still flows
+
+
+def test_query_palace_unreachable_in_warnings(fake_urlopen_factory):
+    fake_urlopen_factory({
+        EVAL_ROUTE: _ok_response_with_warnings(["palace_unreachable", "low_confidence"])
+    })
+    result = FamiliarAdapter().query("x")
+    assert "palace_unreachable" in (result.error or "")
+    assert "WARN" in (result.error or "")
+
+
+def test_query_no_warnings_no_error(fake_urlopen_factory):
+    fake_urlopen_factory({EVAL_ROUTE: _ok_response_with_warnings([])})
+    result = FamiliarAdapter().query("x")
+    assert result.error is None
+
+
+def test_query_server_error_takes_precedence(fake_urlopen_factory):
+    payload = _ok_response_with_warnings(["low_confidence"])
+    payload["error"] = "explicit server error"
+    fake_urlopen_factory({EVAL_ROUTE: payload})
+    result = FamiliarAdapter().query("x")
+    assert "explicit server error" in (result.error or "")
+    assert "low_confidence" in (result.error or "")

--- a/tests/test_familiar_adapter.py
+++ b/tests/test_familiar_adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import socket
 import urllib.error
 
-import pytest
 
 from sme.adapters.familiar import FamiliarAdapter
 
@@ -97,11 +96,6 @@ def test_query_happy_path(fake_urlopen_factory):
 def test_query_default_mock_inference_is_true(fake_urlopen_factory, monkeypatch):
     """Cat 1 determinism guarantee: default mock=true."""
     captured = {}
-
-    def capture(routes):
-        original = routes
-        # Wrap default fake — capture the body before responding
-        return None  # not used; we do this inline below
 
     # Use a custom opener to capture the request body
     import json as _json

--- a/tests/test_familiar_adapter.py
+++ b/tests/test_familiar_adapter.py
@@ -323,3 +323,26 @@ def test_get_harness_manifest_returns_list():
     manifest = FamiliarAdapter(base_url="https://familiar.jphe.in").get_harness_manifest()
     assert isinstance(manifest, list)
     assert len(manifest) in (0, 2)
+
+
+# --- Task 9: CLI dispatch ---
+
+def test_cli_loads_familiar_adapter():
+    """The CLI's --adapter familiar branch instantiates FamiliarAdapter."""
+    from sme.cli import _load_adapter
+    adapter = _load_adapter("familiar", api_url="http://nowhere:1", timeout_s=1.0)
+    assert type(adapter).__name__ == "FamiliarAdapter"
+    assert adapter.base_url == "http://nowhere:1"  # api_url remapped
+
+
+def test_cli_mock_inference_default_when_unset():
+    """When --mock/--no-mock not given, adapter uses its constructor default (True)."""
+    from sme.cli import _load_adapter
+    adapter = _load_adapter("familiar", api_url="http://nowhere:1")
+    assert adapter.mock_inference is True
+
+
+def test_cli_no_mock_passes_through():
+    from sme.cli import _load_adapter
+    adapter = _load_adapter("familiar", api_url="http://nowhere:1", mock_inference=False)
+    assert adapter.mock_inference is False

--- a/tests/test_familiar_adapter.py
+++ b/tests/test_familiar_adapter.py
@@ -296,19 +296,26 @@ def test_get_flat_retrieval_returns_entities_only(fake_urlopen_factory):
         for i in range(3)
     ]
     fake_urlopen_factory({EVAL_ROUTE: body})
-    entities = FamiliarAdapter().get_flat_retrieval("test", k=3)
-    assert len(entities) == 3
-    assert all(e.entity_type == "drawer" for e in entities)
+    result = FamiliarAdapter().get_flat_retrieval("test", k=3)
+    assert result.answer == ""
+    assert result.context_string == ""
+    assert len(result.retrieved_entities) == 3
+    assert all(e.entity_type == "drawer" for e in result.retrieved_entities)
 
 
 def test_get_flat_retrieval_failure_returns_empty(fake_urlopen_factory):
     fake_urlopen_factory({EVAL_ROUTE: (500, {"error": "x"})})
-    entities = FamiliarAdapter().get_flat_retrieval("test")
-    assert entities == []
+    result = FamiliarAdapter().get_flat_retrieval("test")
+    assert result.retrieved_entities == []
+    assert result.error and result.error.startswith("familiar flat-retrieval")
 
 
-def test_get_ontology_source_returns_declared():
-    assert FamiliarAdapter().get_ontology_source() == "declared"
+def test_get_ontology_source_returns_declared_dict():
+    ontology = FamiliarAdapter().get_ontology_source()
+    assert isinstance(ontology, dict)
+    assert ontology["type"] == "declared"
+    assert "schema" in ontology and isinstance(ontology["schema"], list)
+    assert "documentation" in ontology
 
 
 def test_get_harness_manifest_returns_list():

--- a/tests/test_familiar_adapter.py
+++ b/tests/test_familiar_adapter.py
@@ -1,0 +1,48 @@
+"""Unit tests for FamiliarAdapter."""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.error
+
+import pytest
+
+from sme.adapters.familiar import FamiliarAdapter
+
+
+# --- Task 2: instantiation ---
+
+def test_default_construction():
+    adapter = FamiliarAdapter()
+    assert adapter.base_url == "http://familiar:8080"
+    assert adapter.timeout_s == 30.0
+    assert adapter.mock_inference is True
+
+
+def test_explicit_construction():
+    adapter = FamiliarAdapter(
+        base_url="https://familiar.jphe.in",
+        timeout_s=10.0,
+        mock_inference=False,
+    )
+    assert adapter.base_url == "https://familiar.jphe.in"
+    assert adapter.timeout_s == 10.0
+    assert adapter.mock_inference is False
+
+
+def test_base_url_trailing_slash_stripped():
+    adapter = FamiliarAdapter(base_url="https://familiar.jphe.in/")
+    assert adapter.base_url == "https://familiar.jphe.in"
+
+
+# --- Task 3: ingest_corpus stub ---
+
+def test_ingest_corpus_is_noop():
+    adapter = FamiliarAdapter()
+    result = adapter.ingest_corpus([{"id": "doc-1", "text": "anything"}])
+    assert result["entities_created"] == 0
+    assert result["edges_created"] == 0
+    assert result["errors"] == []
+    assert any("diagnostic-only" in w.lower() or "no-op" in w.lower()
+               for w in result["warnings"])

--- a/tests/test_familiar_live.py
+++ b/tests/test_familiar_live.py
@@ -1,0 +1,54 @@
+"""Gated live-smoke test for FamiliarAdapter.
+
+Skipped unless FAMILIAR_BASE_URL is set, e.g.:
+    FAMILIAR_BASE_URL=http://familiar:8080 pytest tests/test_familiar_live.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from sme.adapters.familiar import FamiliarAdapter
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("FAMILIAR_BASE_URL"),
+    reason="set FAMILIAR_BASE_URL to run live smoke",
+)
+
+
+@pytest.fixture
+def adapter() -> FamiliarAdapter:
+    return FamiliarAdapter(
+        base_url=os.environ["FAMILIAR_BASE_URL"],
+        timeout_s=15.0,
+        mock_inference=True,
+    )
+
+
+def test_live_query_returns_query_result(adapter: FamiliarAdapter):
+    """At minimum, query() returns a QueryResult — no exceptions even if
+    palace is rebuilding (which surfaces as a WARN: error string)."""
+    result = adapter.query("realm projects")
+    assert hasattr(result, "answer")
+    assert hasattr(result, "context_string")
+    assert hasattr(result, "retrieved_entities")
+    assert hasattr(result, "retrieved_edges")
+    if result.error:
+        # Acceptable error shapes for live test: WARN: prefix or HTTP code
+        assert (
+            "WARN" in result.error
+            or "endpoint" in result.error
+            or "timeout" in result.error.lower()
+            or "connection" in result.error.lower()
+        )
+
+
+def test_live_get_graph_snapshot_returns_lists(adapter: FamiliarAdapter):
+    entities, edges = adapter.get_graph_snapshot()
+    assert isinstance(entities, list)
+    assert isinstance(edges, list)
+    if not entities:
+        pytest.skip("graph endpoint returned empty — palace may be rebuilding")

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -313,3 +313,124 @@ def test_query_sends_x_api_key_header(
         or captured["headers"].get("X-Api-Key")
     )
     assert api_key_value == "my-secret"
+
+
+# --- get_graph_snapshot — /graph fast path --------------------------
+
+
+_GRAPH_RESPONSE = {
+    "wings": {
+        "memorypalace": 427,
+        "projects": 106183,
+        "umbra": 82,
+    },
+    "rooms": [
+        {"wing": "memorypalace", "rooms": {"architecture": 17, "diary": 235}},
+        {"wing": "projects", "rooms": {"architecture": 9, "general": 100}},
+        {"wing": "umbra", "rooms": {"diary": 12}},
+    ],
+    "tunnels": [
+        {"room": "architecture", "wings": ["memorypalace", "projects"]},
+        {"room": "diary", "wings": ["memorypalace", "umbra"]},
+    ],
+    "kg_entities": [
+        {"id": "e1", "name": "Multipass", "type": "concept", "properties": {}}
+    ],
+    "kg_triples": [
+        {
+            "subject": "e1",
+            "predicate": "described_by",
+            "object": "e1",
+            "valid_from": "2026-04-25",
+            "valid_to": None,
+            "confidence": 1.0,
+            "source_file": "README.md",
+        }
+    ],
+    "kg_stats": {"entities": 1, "triples": 1},
+}
+
+
+def test_snapshot_graph_endpoint_creates_wing_entities(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, edges = a.get_graph_snapshot()
+
+    wing_entities = [e for e in entities if e.entity_type == "wing"]
+    assert {e.name for e in wing_entities} == {"memorypalace", "projects", "umbra"}
+
+
+def test_snapshot_graph_endpoint_creates_room_entities_with_wings(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, _ = a.get_graph_snapshot()
+
+    rooms_by_name = {e.name: e for e in entities if e.id.startswith("room:")}
+    assert "architecture" in rooms_by_name
+    assert sorted(rooms_by_name["architecture"].properties["wings"]) == [
+        "memorypalace",
+        "projects",
+    ]
+    # 'general' is a catch-all and should be skipped, mirroring the
+    # existing direct adapter's filter.
+    assert "general" not in rooms_by_name
+
+
+def test_snapshot_graph_endpoint_member_of_edges(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    _, edges = a.get_graph_snapshot()
+
+    member_of = [e for e in edges if e.edge_type == "member_of"]
+    pairs = {(e.source_id, e.target_id) for e in member_of}
+    assert ("room:architecture", "wing:memorypalace") in pairs
+    assert ("room:architecture", "wing:projects") in pairs
+    assert ("room:diary", "wing:memorypalace") in pairs
+
+
+def test_snapshot_graph_endpoint_tunnel_edges(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    _, edges = a.get_graph_snapshot()
+    tunnels = [e for e in edges if e.edge_type == "tunnel"]
+    pairs = {
+        tuple(sorted([e.source_id, e.target_id]))
+        for e in tunnels
+    }
+    # architecture connects memorypalace<->projects
+    assert ("wing:memorypalace", "wing:projects") in pairs
+    # diary connects memorypalace<->umbra
+    assert ("wing:memorypalace", "wing:umbra") in pairs
+
+
+def test_snapshot_graph_endpoint_kg_entities_and_triples(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": _GRAPH_RESPONSE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, edges = a.get_graph_snapshot()
+    kg_ents = [e for e in entities if e.id.startswith("kg:")]
+    assert len(kg_ents) == 1
+    assert kg_ents[0].name == "Multipass"
+
+    kg_edges = [e for e in edges if e.source_id.startswith("kg:")]
+    assert len(kg_edges) == 1
+    assert kg_edges[0].edge_type == "described_by"

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -556,3 +556,21 @@ def test_snapshot_partial_on_list_rooms_failure(
     entities, _ = a.get_graph_snapshot()
     room_names = {e.name for e in entities if e.id.startswith("room:")}
     assert "r1" in room_names  # the good wing's room is present
+
+
+# --- ontology + ingest -----------------------------------------------
+
+
+def test_get_ontology_source_matches_existing_adapter(monkeypatch, tmp_path):
+    a = _adapter(monkeypatch, tmp_path)
+    ont = a.get_ontology_source()
+    assert ont["type"] == "readme"
+    declared = {entry["kind"] for entry in ont["schema"]}
+    assert "structural" in declared
+    assert "hall_vocabulary" in declared
+
+
+def test_ingest_corpus_raises_with_helpful_message(monkeypatch, tmp_path):
+    a = _adapter(monkeypatch, tmp_path)
+    with pytest.raises(NotImplementedError, match="diagnostic-only"):
+        a.ingest_corpus([])

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import urllib.error
 from pathlib import Path
@@ -434,3 +435,124 @@ def test_snapshot_graph_endpoint_kg_entities_and_triples(
     kg_edges = [e for e in edges if e.source_id.startswith("kg:")]
     assert len(kg_edges) == 1
     assert kg_edges[0].edge_type == "described_by"
+
+
+# --- get_graph_snapshot — MCP fallback ------------------------------
+
+
+def _mcp_envelope(payload) -> dict:
+    """Build an MCP tools/call response envelope wrapping a JSON payload."""
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": json.dumps(payload)}]},
+    }
+
+
+def _mcp_request_router(routes_by_tool: dict):
+    """Returns a callable that fake_urlopen_factory can hand back as the
+    response for ``POST http://daemon/mcp``.
+
+    Inspects the request body to dispatch on (tool_name, arguments) and
+    returns the matching MCP envelope. Unknown tools raise AssertionError.
+    """
+    def _route(req, *, _routes=routes_by_tool):
+        body = req.data
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        rpc = json.loads(body)
+        params = rpc.get("params") or {}
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        # Per-wing list_rooms: key on tool:wing
+        if name == "mempalace_list_rooms":
+            key = f"mempalace_list_rooms:{args.get('wing')}"
+        else:
+            key = name
+        if key not in _routes:
+            raise AssertionError(f"unrouted MCP call: {key}")
+        result = _routes[key]
+        if isinstance(result, Exception):
+            raise result
+        return _mcp_envelope(result)
+    return _route
+
+
+def test_snapshot_falls_back_to_mcp_on_404(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/graph": (
+            urllib.error.HTTPError(
+                "http://daemon/graph", 404, "Not Found", {}, None
+            )
+        ),
+        "POST http://daemon/mcp": _mcp_request_router({
+            "mempalace_list_wings": {
+                "wings": {"memorypalace": 427, "umbra": 82}
+            },
+            "mempalace_list_tunnels": [
+                {"room": "diary", "wings": ["memorypalace", "umbra"]}
+            ],
+            "mempalace_list_rooms:memorypalace": {
+                "wing": "memorypalace",
+                "rooms": {"diary": 235, "architecture": 17},
+            },
+            "mempalace_list_rooms:umbra": {
+                "wing": "umbra",
+                "rooms": {"diary": 12},
+            },
+        }),
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, edges = a.get_graph_snapshot()
+    wing_names = {e.name for e in entities if e.entity_type == "wing"}
+    assert wing_names == {"memorypalace", "umbra"}
+    tunnels = [e for e in edges if e.edge_type == "tunnel"]
+    assert len(tunnels) == 1
+    pair = tuple(sorted([tunnels[0].source_id, tunnels[0].target_id]))
+    assert pair == ("wing:memorypalace", "wing:umbra")
+
+
+def test_snapshot_force_mcp_with_prefer_graph_false(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "POST http://daemon/mcp": _mcp_request_router({
+            "mempalace_list_wings": {"wings": {"only": 1}},
+            "mempalace_list_tunnels": [],
+            "mempalace_list_rooms:only": {"wing": "only", "rooms": {}},
+        }),
+    })
+    a = _adapter(
+        monkeypatch, tmp_path, prefer_graph_endpoint=False
+    )
+    entities, _ = a.get_graph_snapshot()
+    # Should NOT have hit /graph at all (no route registered for it)
+    wing_names = {e.name for e in entities if e.entity_type == "wing"}
+    assert wing_names == {"only"}
+
+
+def test_snapshot_partial_on_list_rooms_failure(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    """If list_rooms fails for one wing, the snapshot still returns
+    every other wing's data."""
+    fake_urlopen_factory({
+        "GET http://daemon/graph": urllib.error.HTTPError(
+            "http://daemon/graph", 404, "Not Found", {}, None
+        ),
+        "POST http://daemon/mcp": _mcp_request_router({
+            "mempalace_list_wings": {"wings": {"good": 1, "bad": 1}},
+            "mempalace_list_tunnels": [],
+            "mempalace_list_rooms:good": {"wing": "good", "rooms": {"r1": 5}},
+            # 'bad' wing's list_rooms raises
+            "mempalace_list_rooms:bad": urllib.error.HTTPError(
+                "http://daemon/mcp", 500, "tool error", {}, None
+            ),
+        }),
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    entities, _ = a.get_graph_snapshot()
+    room_names = {e.name for e in entities if e.id.startswith("room:")}
+    assert "r1" in room_names  # the good wing's room is present

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -1,0 +1,70 @@
+"""Tests for sme.adapters.mempalace_daemon — HTTP-mocked, no live daemon."""
+
+from __future__ import annotations
+
+import os
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+
+
+# --- Auth resolution -------------------------------------------------
+
+
+def test_auth_explicit_kwargs_win(monkeypatch, tmp_path):
+    env_file = tmp_path / "env"
+    env_file.write_text("PALACE_API_KEY=from-file\nPALACE_DAEMON_URL=http://from-file\n")
+    monkeypatch.setenv("PALACE_API_KEY", "from-env")
+    monkeypatch.setenv("PALACE_DAEMON_URL", "http://from-env")
+
+    a = MemPalaceDaemonAdapter(
+        api_url="http://explicit",
+        api_key="explicit-key",
+        env_file=env_file,
+    )
+    assert a.api_url == "http://explicit"
+    assert a.api_key == "explicit-key"
+
+
+def test_auth_env_file_used_when_no_kwargs(monkeypatch, tmp_path):
+    env_file = tmp_path / "env"
+    env_file.write_text(
+        'PALACE_API_KEY="from-file"\nPALACE_DAEMON_URL=http://from-file:8085\n'
+    )
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+
+    a = MemPalaceDaemonAdapter(env_file=env_file)
+    assert a.api_url == "http://from-file:8085"
+    assert a.api_key == "from-file"
+
+
+def test_auth_process_env_used_when_env_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("PALACE_API_KEY", "from-env")
+    monkeypatch.setenv("PALACE_DAEMON_URL", "http://from-env:8085")
+
+    a = MemPalaceDaemonAdapter(env_file=tmp_path / "does-not-exist")
+    assert a.api_url == "http://from-env:8085"
+    assert a.api_key == "from-env"
+
+
+def test_auth_raises_when_nothing_resolves(monkeypatch, tmp_path):
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+
+    with pytest.raises(ValueError, match="api_url"):
+        MemPalaceDaemonAdapter(env_file=tmp_path / "nope")
+
+
+def test_auth_url_trailing_slash_is_stripped(monkeypatch, tmp_path):
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+    a = MemPalaceDaemonAdapter(
+        api_url="http://example/",
+        api_key="k",
+        env_file=tmp_path / "nope",
+    )
+    assert a.api_url == "http://example"

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -68,3 +68,129 @@ def test_auth_url_trailing_slash_is_stripped(monkeypatch, tmp_path):
         env_file=tmp_path / "nope",
     )
     assert a.api_url == "http://example"
+
+
+# --- query() ---------------------------------------------------------
+
+
+_OK_ENVELOPE = {
+    "query": "memory",
+    "filters": {"wing": None, "room": None},
+    "total_before_filter": 3,
+    "available_in_scope": 150811,
+    "warnings": [],
+    "results": [
+        {
+            "text": "first chunk text",
+            "metadata": {
+                "wing": "memorypalace",
+                "room": "architecture",
+                "source_file": "/path/to/notes.md",
+            },
+            "score": 0.91,
+        },
+        {
+            "text": "second chunk",
+            "metadata": {
+                "wing": "memorypalace",
+                "room": "diary",
+                "source_file": "/path/to/diary.md",
+            },
+            "score": 0.84,
+        },
+    ],
+}
+
+
+def _adapter(monkeypatch, tmp_path, **kwargs):
+    monkeypatch.delenv("PALACE_API_KEY", raising=False)
+    monkeypatch.delenv("PALACE_DAEMON_URL", raising=False)
+    defaults = dict(
+        api_url="http://daemon",
+        api_key="key",
+        env_file=tmp_path / "no-env",
+    )
+    defaults.update(kwargs)
+    return MemPalaceDaemonAdapter(**defaults)
+
+
+def test_query_success_builds_context_string(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error is None
+    assert "[1] [memorypalace/architecture]" in result.context_string
+    assert "first chunk text" in result.context_string
+    assert "[2] [memorypalace/diary]" in result.context_string
+    assert "second chunk" in result.context_string
+    # Source filename basenames, not full paths
+    assert "notes.md" in result.context_string
+    assert "/path/to/notes.md" not in result.context_string
+
+
+def test_query_retrieved_entities_have_wing_room_score(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert len(result.retrieved_entities) == 2
+    e0 = result.retrieved_entities[0]
+    assert e0.entity_type == "drawer:architecture"
+    assert e0.properties["wing"] == "memorypalace"
+    assert e0.properties["room"] == "architecture"
+    assert e0.properties["score"] == 0.91
+
+
+def test_query_retrieval_path_includes_kind_and_counts(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    path_str = "; ".join(result.retrieval_path)
+    assert "kind=content" in path_str
+    assert "available_in_scope=150811" in path_str
+    assert "total_before_filter=3" in path_str
+
+
+def test_query_kind_kwarg_overrides_default(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=all": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)  # kind defaults to "content"
+    result = a.query("memory", kind="all")
+    assert "kind=all" in "; ".join(result.retrieval_path)
+
+
+def test_query_n_results_threads_through_to_limit(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=12&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory", n_results=12)
+    assert result.error is None  # would AssertionError in fake_urlopen otherwise
+
+
+def test_query_question_is_url_quoted(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        # spaces and ampersands must be quoted in the URL
+        "GET http://daemon/search?q=hello+world+%26+more&limit=5&kind=content": _OK_ENVELOPE,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("hello world & more")
+    assert result.error is None

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import json
-import os
 import urllib.error
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_mempalace_daemon_adapter.py
+++ b/tests/test_mempalace_daemon_adapter.py
@@ -194,3 +194,122 @@ def test_query_question_is_url_quoted(
     a = _adapter(monkeypatch, tmp_path)
     result = a.query("hello world & more")
     assert result.error is None
+
+
+# --- query() error paths --------------------------------------------
+
+
+def test_query_warnings_emit_soft_error_with_results(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    envelope = {
+        **_OK_ENVELOPE,
+        "warnings": ["vector search unavailable: Error finding id"],
+    }
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": envelope,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    # Soft signal: error set, but context_string still populated
+    assert result.error is not None
+    assert result.error.startswith("WARN:")
+    assert "vector search unavailable" in result.error
+    assert "first chunk text" in result.context_string
+
+
+def test_query_warnings_with_empty_results(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    envelope = {
+        "query": "memory",
+        "filters": {"wing": None, "room": None},
+        "total_before_filter": 0,
+        "available_in_scope": 150811,
+        "warnings": ["vector search unavailable: Error finding id"],
+        "results": [],
+    }
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": envelope,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("WARN:")
+    assert result.context_string == ""
+
+
+def test_query_no_results_returns_no_results(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    envelope = {**_OK_ENVELOPE, "results": [], "warnings": []}
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": envelope,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error == "NO_RESULTS"
+
+
+def test_query_auth_error_returns_AUTH(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    err = urllib.error.HTTPError(
+        "http://daemon/search", 401, "Unauthorized", {}, None
+    )
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": err,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("AUTH:")
+    assert "401" in result.error
+
+
+def test_query_5xx_returns_HTTP_error(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    err = urllib.error.HTTPError(
+        "http://daemon/search", 500, "Server Error", {}, None
+    )
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": err,
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("HTTP 500")
+
+
+def test_query_connection_refused_returns_CONNECTION(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": (
+            urllib.error.URLError("Connection refused")
+        ),
+    })
+    a = _adapter(monkeypatch, tmp_path)
+    result = a.query("memory")
+    assert result.error.startswith("CONNECTION:")
+
+
+def test_query_sends_x_api_key_header(
+    monkeypatch, tmp_path, fake_urlopen_factory
+):
+    captured = {}
+
+    def capture(req):
+        captured["headers"] = dict(req.header_items())
+        captured["url"] = req.full_url
+        return _OK_ENVELOPE  # factory will wrap into a _FakeResponse
+
+    fake_urlopen_factory({
+        "GET http://daemon/search?q=memory&limit=5&kind=content": capture,
+    })
+    a = _adapter(monkeypatch, tmp_path, api_key="my-secret")
+    a.query("memory")
+    # urllib normalises header names; check both casings
+    api_key_value = (
+        captured["headers"].get("X-api-key")
+        or captured["headers"].get("X-Api-Key")
+    )
+    assert api_key_value == "my-secret"

--- a/tests/test_mempalace_daemon_integration.py
+++ b/tests/test_mempalace_daemon_integration.py
@@ -21,8 +21,8 @@ from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
 
 
 pytestmark = pytest.mark.skipif(
-    not os.environ.get("PALACE_DAEMON_URL"),
-    reason="needs a running palace-daemon; set PALACE_DAEMON_URL to enable",
+    not (os.environ.get("PALACE_DAEMON_URL") and os.environ.get("PALACE_API_KEY")),
+    reason="needs a running palace-daemon; set PALACE_DAEMON_URL and PALACE_API_KEY to enable",
 )
 
 

--- a/tests/test_mempalace_daemon_integration.py
+++ b/tests/test_mempalace_daemon_integration.py
@@ -47,25 +47,32 @@ def test_snapshot_returns_at_least_one_wing(adapter):
     assert len(wing_names) >= 1
 
 
-def test_kind_default_excludes_more_than_kind_all(adapter):
-    """Cross-check the README's claim: kind='content' filters strictly
-    less than kind='all'. If the live palace has any auto-save
-    checkpoints, this assertion holds; on a fresh palace it might be
-    equal — assert >= rather than > to avoid flakes."""
-    r_all = adapter.query("the", n_results=5, kind="all")
-    r_content = adapter.query("the", n_results=5, kind="content")
-    # We can't compare result counts directly because limit caps both;
-    # use total_before_filter from retrieval_path.
-    def total_before(rp):
-        for s in rp:
-            if s.startswith("total_before_filter="):
-                # value may be 'None' on errored queries
-                v = s.split("=", 1)[1]
-                try:
-                    return int(v)
-                except ValueError:
-                    return -1
-        return -1
-    assert total_before(r_all.retrieval_path) >= total_before(
-        r_content.retrieval_path
+def test_kind_content_excludes_stop_hook_checkpoints(adapter):
+    """Cross-check the README's behavioural claim: kind='content'
+    excludes Stop-hook auto-save checkpoints (which start with
+    'CHECKPOINT:' in the live palace) while kind='all' includes them.
+
+    The earlier-shape assertion on total_before_filter conflated
+    metadata math with filter behaviour — `total_before_filter` is
+    not "scope size before kind filter". The reliable signal is in
+    the returned context_string itself: do CHECKPOINT: strings
+    appear or not?
+    """
+    r_all = adapter.query("CHECKPOINT", n_results=5, kind="all")
+    r_content = adapter.query("CHECKPOINT", n_results=5, kind="content")
+
+    # If the live palace has zero checkpoints, both will be empty —
+    # skip rather than fail.
+    if "CHECKPOINT:" not in (r_all.context_string or ""):
+        pytest.skip(
+            "live palace has no Stop-hook checkpoints to test against"
+        )
+
+    # The behavioural invariant: kind='content' must have strictly
+    # fewer (or zero) CHECKPOINT: strings than kind='all'.
+    n_all = (r_all.context_string or "").count("CHECKPOINT:")
+    n_content = (r_content.context_string or "").count("CHECKPOINT:")
+    assert n_content < n_all, (
+        f"kind='content' should filter checkpoints, got "
+        f"{n_content} vs {n_all} for kind='all'"
     )

--- a/tests/test_mempalace_daemon_integration.py
+++ b/tests/test_mempalace_daemon_integration.py
@@ -1,0 +1,71 @@
+"""Live-daemon smoke tests for MemPalaceDaemonAdapter.
+
+Skipped automatically when PALACE_DAEMON_URL is not set in the
+environment, so CI without a daemon stays green. Run locally with:
+
+    PALACE_DAEMON_URL=http://disks.jphe.in:8085 \
+    PALACE_API_KEY=$(grep ^PALACE_API_KEY ~/.config/palace-daemon/env | cut -d= -f2) \
+    pytest tests/test_mempalace_daemon_integration.py -v
+
+The tests are read-only: query() and get_graph_snapshot() only.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from sme.adapters.base import QueryResult
+from sme.adapters.mempalace_daemon import MemPalaceDaemonAdapter
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("PALACE_DAEMON_URL"),
+    reason="needs a running palace-daemon; set PALACE_DAEMON_URL to enable",
+)
+
+
+@pytest.fixture
+def adapter():
+    a = MemPalaceDaemonAdapter()
+    yield a
+    a.close()
+
+
+def test_query_returns_query_result(adapter):
+    r = adapter.query("hello", n_results=2)
+    assert isinstance(r, QueryResult)
+    # Either we got results, or we got a soft-warn / NO_RESULTS — never an
+    # uncaught exception.
+
+
+def test_snapshot_returns_at_least_one_wing(adapter):
+    entities, _ = adapter.get_graph_snapshot()
+    wing_names = {e.name for e in entities if e.entity_type == "wing"}
+    # Live palace has 30+ wings on JP's install; even a fresh palace has >=1.
+    assert len(wing_names) >= 1
+
+
+def test_kind_default_excludes_more_than_kind_all(adapter):
+    """Cross-check the README's claim: kind='content' filters strictly
+    less than kind='all'. If the live palace has any auto-save
+    checkpoints, this assertion holds; on a fresh palace it might be
+    equal — assert >= rather than > to avoid flakes."""
+    r_all = adapter.query("the", n_results=5, kind="all")
+    r_content = adapter.query("the", n_results=5, kind="content")
+    # We can't compare result counts directly because limit caps both;
+    # use total_before_filter from retrieval_path.
+    def total_before(rp):
+        for s in rp:
+            if s.startswith("total_before_filter="):
+                # value may be 'None' on errored queries
+                v = s.split("=", 1)[1]
+                try:
+                    return int(v)
+                except ValueError:
+                    return -1
+        return -1
+    assert total_before(r_all.retrieval_path) >= total_before(
+        r_content.retrieval_path
+    )


### PR DESCRIPTION
Second in a three-PR stack. Stacked on [`feat/mempalace-daemon-adapter`](https://github.com/M0nkeyFl0wer/multipass-structural-memory-eval/pull/5) — please merge that one first; this PR's diff against `main` will collapse to just the new commits afterward.

### Summary

Three logically-grouped pieces ride together because they're tightly coupled — the corpus was authored to exercise both adapters, and the lessons doc is the writeup that came out of running them:

- **`FamiliarAdapter`** — read-side adapter for [familiar.realm.watch](https://github.com/jphein/familiar.realm.watch), a deterministic retrieve→rerank→decay→compress pipeline that wraps a palace. Pairs cleanly with `MemPalaceDaemonAdapter` for A/B work.
- **`jp-realm-v0.1` corpus** — 30-question hand-authored corpus (27 single-hop, 3 two-hop) covering JP's homelab + project knowledge. Authoring contract follows the spec's existing per-corpus convention; lives at `sme/corpora/jp_realm_v0_1/questions.yaml`.
- **First live readings** — head-to-head familiar vs daemon baselines, plus the v0.3 reflect-pipeline iterations that came out of running them. `docs/ideas.md` gains a "Lessons from the first live eval" section synthesizing what surfaced.

### Design + plan docs in the PR

- `docs/superpowers/specs/2026-04-26-familiar-adapter-design.md`
- `docs/superpowers/plans/2026-04-26-familiar-adapter.md`

### Notable refactor

`refactor(adapters): extract /graph payload mapping into shared module` (commit `4f213db` in this PR) extracts the `/graph` snapshot mapping that both `FamiliarAdapter` and `MemPalaceDaemonAdapter` need, into `sme/adapters/_graph_mapping.py`. The daemon adapter is updated to use the shared module in this PR rather than the prior PR — keeps the prior PR scoped to "introduce the daemon adapter" and the refactor scoped to "share the part that's now duplicated."

### Lessons doc highlights

The new section in `docs/ideas.md` captures the diagnostic patterns that fell out of the first run — including the **system-gap-vs-pipeline-gap** split that the q12/q13 case study illustrates (writing the missing drawers via palace-daemon flipped q12 from 0.0 to 1.0 — palace gap; left q13 at 0.0 — pipeline gap). This is the diagnostic the framework was built to provide; nice to see it land cleanly with the simplest possible scoring.

### Testing

- `tests/test_familiar_adapter.py` — 26 tests covering query happy/error paths, graph snapshot, ingest stub, mock/no-mock modes, timeout behavior.
- `tests/test_familiar_live.py` — gated live smoke (requires `FAMILIAR_LIVE=1`), skipped in CI.
- All daemon tests from PR 1 still pass after the shared-module refactor.

### Test plan

- [ ] `python -m pytest tests/test_familiar_adapter.py tests/test_mempalace_daemon_adapter.py -v` — 54 tests pass (26 familiar + 28 daemon)
- [ ] `sme-eval retrieve --adapter familiar --questions sme/corpora/jp_realm_v0_1/questions.yaml --familiar-url $URL` — CLI smoke against a running familiar
- [ ] `cat baselines/jp_realm_v0_1_familiar_*.json | jq '.summary.mean_recall'` — eyeball the recall progression across the v0.2/v0.3 baselines

The 19 commits split into design/plan, shared-module refactor, scaffold, query, graph snapshot, CLI wiring, then corpus authoring and the v0.2/v0.3 baseline iterations + lessons doc in roughly that order. Happy to walk through any specific commit if useful.