### PR TITLE
fix: Cat9b None-vs-0.0, flat_rarity_mode flag, spec caveats, starter corpus, v0.2.0

### DIFF
--- a/docs/sme_spec_v8.md
+++ b/docs/sme_spec_v8.md
@@ -1,5 +1,13 @@
 # Structural Memory Evaluation (SME) Framework — v8
 
+> **Status: this spec describes the target design.** Several CLI commands
+> referenced below are not yet implemented in `sme/cli.py`. The
+> implemented set (as of 2026-05-22) is: `analyze`, `retrieve`, `cat4`,
+> `cat5`, `cat8`, `cat2c`, `cat9`, and `check`. Commands marked 🚧 in
+> this document are planned but not built yet — call them out when
+> reviewing PRs that reference them. See the README's "Status" section
+> for the canonical list of shipped commands and adapters.
+>
 > **Version note.** Originally `sme_spec_v5.md`; content level matches v8
 > (Category 8 ontology coherence, multi-hop 2c sub-test, introspection/external
 > splits on Categories 4/5/8, operationalized claim library, use-case profiles,
@@ -237,11 +245,11 @@ Many embedded graph databases (LadybugDB among them) take a single-writer file l
 
 SME provides two paths around it:
 
-1. **`sme-eval snapshot --db-path PATH --output SNAPSHOT`** — copies the database file (and any sibling WAL / shadow files) to a specified output location, preserving any on-disk consistency guarantees the target DB provides. Produces a point-in-time backup suitable for benchmarking. Call this before `sme-eval run` when the target is in active use.
+1. 🚧 **`sme-eval snapshot --db-path PATH --output SNAPSHOT`** (not yet implemented) — copies the database file (and any sibling WAL / shadow files) to a specified output location, preserving any on-disk consistency guarantees the target DB provides. Produces a point-in-time backup suitable for benchmarking. Call this before `sme-eval run` when the target is in active use. Note: the daemon adapter has no file path; this command applies only to file-backed adapters like LadybugDB.
 
 2. **API-based adapters** — where the system under test exposes an HTTP search API, an adapter can read through the API rather than opening the file directly. Higher fidelity (reads the current live state) but requires the target's API to expose graph introspection endpoints.
 
-The reference LadybugDB adapter opens with `read_only=True` by default but will surface a clear error if the writer lock blocks access, pointing the user to `sme-eval snapshot`.
+The reference LadybugDB adapter opens with `read_only=True` by default but will surface a clear error if the writer lock blocks access, pointing the user to `sme-eval snapshot` (🚧 not yet implemented).
 
 ### Built-in Flat Baseline
 
@@ -355,7 +363,7 @@ class TopologyAnalyzer:
 
 ### Corpus Calibration (codetopo method)
 
-`sme-eval calibrate` verifies the seeded corpus against a frozen reference, not exploratory analysis. The reference ships as `sme/corpora/standard_v1/calibration.json`:
+🚧 `sme-eval calibrate` (not yet implemented) is intended to verify the seeded corpus against a frozen reference, not exploratory analysis. The reference would ship as `sme/corpora/standard_v1/calibration.json`:
 
 ```json
 {
@@ -374,14 +382,14 @@ class TopologyAnalyzer:
 }
 ```
 
-`sme-eval calibrate` first checks `corpus_sha256` against the actual corpus tree (YAML + vault). If the hash doesn't match, calibration is stale — someone edited the corpus without re-running calibration. The tool aborts with a specific diagnostic. Then it re-computes structural properties and diffs against the frozen reference. If any value drifts beyond threshold, calibration fails with a specific diagnostic. Calibration results are versioned with the corpus — anyone can reproduce.
+When implemented, `sme-eval calibrate` will first check `corpus_sha256` against the actual corpus tree (YAML + vault). If the hash doesn't match, calibration is stale — someone edited the corpus without re-running calibration. The tool aborts with a specific diagnostic. Then it re-computes structural properties and diffs against the frozen reference. If any value drifts beyond threshold, calibration fails with a specific diagnostic. Calibration results are versioned with the corpus — anyone can reproduce.
 
 **Thresholds:**
 - "Disconnected" = shortest path > 4 hops between gap communities (no accidental bridges)
 - Alias pairs must have Jaccard string similarity < 0.25 AND cosine semantic similarity > 0.78 (confirms testing canonicalization, not fuzzy match)
 - Runaway cluster must be in its own connected component
 
-**On failure:** `sme-eval calibrate --repair` attempts automated fixes (removing accidental bridge edges, adjusting defect placement). If repair fails, manual intervention required. The tool outputs exactly which property failed and why.
+**On failure (planned):** 🚧 `sme-eval calibrate --repair` (not yet implemented) is intended to attempt automated fixes (removing accidental bridge edges, adjusting defect placement). If repair fails, manual intervention required. The tool outputs exactly which property failed and why.
 
 ### Seeded Corpus: v0.1 Specification
 
@@ -609,7 +617,7 @@ calibration:
   # Report judge-human agreement for YOUR corpus, not just LongMemEval's
 ```
 
-`sme-eval run --dry-run` estimates judge cost across all categories × conditions × queries and aborts if it exceeds the budget. No surprise bills.
+🚧 `sme-eval run --dry-run` (not yet implemented) is intended to estimate judge cost across all categories × conditions × queries and abort if it exceeds the budget. No surprise bills.
 
 ---
 
@@ -632,12 +640,15 @@ The adapter's `get_ontology_source()` method returns whichever is available. The
 The extraction is a one-time tool, not part of the benchmark loop. Run it once, commit the result as `implied_ontology.yaml` in the adapter directory. SME reads the YAML during eval — no LLM call in the benchmark path.
 
 ```bash
+# 🚧 Not yet implemented — placeholder design.
 # One-time: extract implied ontology from README
 sme-eval extract-ontology --readme path/to/README.md --output implied_ontology.yaml
 
 # The LLM call is cached by sha256(readme + configs)
 # Re-running on identical input returns cached result
 ```
+
+For now, hand-author `implied_ontology.yaml` files (see `sme/corpora/implied_ontology_mempalace.yaml` for an example) and pass them to `sme-eval cat8 --implied-ontology …`.
 
 ```python
 @dataclass
@@ -899,6 +910,26 @@ Topology summary
 
 ## CLI
 
+### Implemented today
+
+```bash
+# Analyze a graph snapshot and print structural reading
+sme-eval analyze --adapter mempalace-daemon --api-url http://… --betti
+
+# Per-category readings
+sme-eval cat4  --adapter <name> …            # ingestion integrity
+sme-eval cat5  --adapter <name> …            # gap detection
+sme-eval cat8  --adapter <name> --implied-ontology …  # ontology coherence
+sme-eval cat9  --adapter <name> …            # harness integration (9b only)
+sme-eval cat2c --graph results.json …        # multi-hop scorecard
+
+# Retrieval probe + check shortcut
+sme-eval retrieve --adapter <name> --questions corpus.yaml --json out.json
+sme-eval check    --adapter <name> …         # cat4 + cat5 combined
+```
+
+### 🚧 Planned (not yet implemented)
+
 ```bash
 sme-eval run --config sme_config.yaml
 sme-eval run --config sme_config.yaml --category ingestion_integrity
@@ -906,7 +937,13 @@ sme-eval compare --configs ladybugdb.yaml mempalace.yaml flat.yaml --output repo
 sme-eval calibrate --corpus sme/corpora/standard_v1.yaml
 sme-eval viz --config sme_config.yaml --output report/graph_snapshot.html
 sme-eval report --scores report/raw_scores.json --output report/
+sme-eval snapshot --db-path PATH --output SNAPSHOT
+sme-eval extract-ontology --readme path/to/README.md --output implied_ontology.yaml
 ```
+
+These commands are referenced throughout this spec for the full target
+design. Tracking issues:
+[#6](https://github.com/techempower-org/multipass-structural-memory-eval/issues/6).
 
 ---
 

--- a/sme/__init__.py
+++ b/sme/__init__.py
@@ -1,3 +1,3 @@
 """sme-eval: Structural Memory Evaluation framework."""
 
-__version__ = "0.0.1"
+__version__ = "0.2.0"

--- a/sme/categories/gap_detection.py
+++ b/sme/categories/gap_detection.py
@@ -86,6 +86,13 @@ class GapDetectionReport:
     # Pre-filter total, so a maintainer can tell "we filtered 21k → 20"
     candidate_gaps_considered: int = 0
 
+    # True when the rarity fallback fired (≤ 2 sized components, every
+    # shared type weighted as 1.0). In this regime the score scales
+    # linearly with shared-type count — a 100-shared-type degenerate
+    # pair scores 100× a 1-shared-rare-type pair, which is misleading
+    # if the consumer doesn't know it's the flat-rarity branch.
+    flat_rarity_mode: bool = False
+
     # When seeded_missing_edges is provided
     gap_recall: Optional[float] = None
     gap_precision: Optional[float] = None
@@ -117,7 +124,7 @@ def _candidate_gaps(
     min_size: int = 3,
     max_type_prevalence: float = 0.5,
     top_k: int = 20,
-) -> tuple[list[CandidateGap], int]:
+) -> tuple[list[CandidateGap], int, bool]:
     """Rank candidate missing-edge pairs across components.
 
     A pair ``(comp_i, comp_j)`` is considered only when both components
@@ -135,15 +142,16 @@ def _candidate_gaps(
     The √min size term prevents a huge component from dominating every
     pair it participates in.
 
-    Returns ``(top_k_gaps, total_pairs_considered)`` so a caller can
-    report "showing 20 of 1,847 considered."
+    Returns ``(top_k_gaps, total_pairs_considered, flat_rarity_mode)``
+    so a caller can report "showing 20 of 1,847 considered" and flag
+    when the rarity-weighting fallback was active.
     """
     if len(components) < 2:
-        return [], 0
+        return [], 0, False
 
     sized_indices = [i for i, c in enumerate(components) if len(c) >= min_size]
     if len(sized_indices) < 2:
-        return [], 0
+        return [], 0, False
 
     type_by_comp: dict[int, set[str]] = {}
     nodes_by_comp: dict[int, list[str]] = {}
@@ -220,7 +228,7 @@ def _candidate_gaps(
             )
 
     scored.sort(key=lambda g: g.score, reverse=True)
-    return scored[:top_k], considered
+    return scored[:top_k], considered, flat_rarity_mode
 
 
 def score_gap_detection(
@@ -290,7 +298,7 @@ def score_gap_detection(
                 "Betti-1 persistence readings"
             )
 
-    candidates, considered = _candidate_gaps(
+    candidates, considered, flat_rarity_mode = _candidate_gaps(
         analyzer,
         components,
         min_size=min_component_size,
@@ -311,19 +319,19 @@ def score_gap_detection(
         }
 
         recalled = 0
-        considered = 0
+        seeded_considered = 0
         for u, v in seeded_missing_edges:
             cu = node_to_comp.get(u)
             cv = node_to_comp.get(v)
             if cu is None or cv is None:
                 continue
-            considered += 1
+            seeded_considered += 1
             if cu == cv:
                 continue  # Endpoints already in same component — not a cross-cluster gap
             if frozenset({cu, cv}) in reported_pairs:
                 recalled += 1
 
-        gap_recall = (recalled / considered) if considered else 0.0
+        gap_recall = (recalled / seeded_considered) if seeded_considered else 0.0
         gap_precision = (
             (recalled / len(reported_pairs)) if reported_pairs else 0.0
         )
@@ -342,6 +350,7 @@ def score_gap_detection(
         h1_skip_reason=h1_skip_reason,
         candidate_gaps=candidates,
         candidate_gaps_considered=considered,
+        flat_rarity_mode=flat_rarity_mode,
         gap_recall=gap_recall,
         gap_precision=gap_precision,
     )
@@ -423,6 +432,12 @@ def format_report(report: GapDetectionReport) -> str:
         f"  Candidate gaps:        {len(report.candidate_gaps):,} shown"
         f" of {report.candidate_gaps_considered:,} considered"
     )
+    if report.flat_rarity_mode:
+        lines.append(
+            "    (flat-rarity mode: ≤2 sized components — every shared "
+            "type weighted 1.0; scores scale linearly with shared-type "
+            "count, not rarity)"
+        )
     for gap in report.candidate_gaps[:5]:
         lines.append(
             f"    [score {gap.score:5.2f}]  "

--- a/sme/categories/harness_integration.py
+++ b/sme/categories/harness_integration.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
+from typing import Optional
 
 from sme.adapters.base import HarnessDescriptor, ProbeResult, SMEAdapter
 
@@ -83,7 +84,17 @@ class Cat9bResult:
     empty_manifest: bool = False
 
     @property
-    def call_through_rate(self) -> float:
+    def call_through_rate(self) -> Optional[float]:
+        """Fraction of declared surfaces that answered.
+
+        Returns ``None`` when the adapter declares no harness manifest —
+        a "not measured" signal distinct from "every probe failed"
+        (which would be ``0.0``). Consumers reading the JSON should
+        treat ``null`` as "Cat 9b does not apply to this system" and
+        ``0.0`` as a measured floor.
+        """
+        if self.empty_manifest:
+            return None
         if self.total_probes == 0:
             return 0.0
         return self.successful_probes / self.total_probes
@@ -92,7 +103,10 @@ class Cat9bResult:
     def band(self) -> str:
         if self.empty_manifest:
             return "n/a"
-        return _band(self.call_through_rate, _CALL_THROUGH_HEALTHY, _CALL_THROUGH_WARN)
+        rate = self.call_through_rate
+        if rate is None:
+            return "n/a"
+        return _band(rate, _CALL_THROUGH_HEALTHY, _CALL_THROUGH_WARN)
 
 
 # --- Sub-test: 9b call-through success --------------------------------
@@ -202,7 +216,8 @@ def format_cat9b_report(result: Cat9bResult, *, source_label: str = "") -> str:
         )
         return "\n".join(lines) + "\n"
 
-    rate_pct = result.call_through_rate * 100
+    rate = result.call_through_rate
+    rate_pct = (rate * 100) if rate is not None else 0.0
     lines.append(
         f"  Probes: {result.total_probes} total — "
         f"{result.successful_probes} succeeded, "

--- a/sme/corpora/standard_v0_1/AUTHORING.md
+++ b/sme/corpora/standard_v0_1/AUTHORING.md
@@ -4,6 +4,8 @@
 
 **Principle:** Hand-author everything. No LLM synthesis, no dataset adaptation. At 30 notes this is 2-3 hours of writing. The payoff is that every ground-truth answer is verified and every defect is intentional.
 
+**Starting point:** [`questions.yaml`](questions.yaml) ships nine reference questions covering the multi-hop chain A, the temporal evolution chain, one contradiction pair, and one alias pair from the schema below. Use it as a working template, then expand to the full 50-question set described in this document as you author the corresponding vault notes.
+
 ---
 
 ## Corpus structure

--- a/sme/corpora/standard_v0_1/questions.yaml
+++ b/sme/corpora/standard_v0_1/questions.yaml
@@ -1,0 +1,110 @@
+# standard_v0_1 — reference questions
+#
+# Minimal example questions for the v0.1 starter corpus. Use this file
+# as a template when authoring your own questions.yaml against the
+# `standard_v0_1/vault/` content described in AUTHORING.md.
+#
+# Schema (matches `sme-eval retrieve` consumer):
+#   - id:                stable identifier for per-question reporting
+#   - text:              the prompt sent to the adapter's query()
+#   - expected_sources:  substrings that should appear in the adapter's
+#                        QueryResult.context_string when retrieval works
+#   - min_hops:          ground-truth hop depth in the corpus graph
+#                        (0 = direct, 1+ = multi-hop reasoning required)
+#
+# These nine questions are pulled from the chains documented in
+# `AUTHORING.md` (auth_engineering, infrastructure, temporal,
+# alias-pair, contradiction). Once you've hand-authored the vault
+# notes called out in AUTHORING.md, every `expected_sources` substring
+# below should be present in the corresponding markdown file.
+#
+# `sme-eval retrieve --questions sme/corpora/standard_v0_1/questions.yaml \`
+# `    --adapter <your-adapter> --json out.json`
+
+version: standard-v0.1
+description: |
+  Reference questions for the v0.1 starter corpus. Multi-hop chain A
+  (Kai → OAuth → Driftwood), the infrastructure temporal evolution
+  (PostgreSQL → SQLite → PostgreSQL), one auth contradiction pair
+  (Clerk vs Auth0), and one alias pair (ZK proof / zero-knowledge).
+  Expand to the full 50-question set described in AUTHORING.md as
+  you author the corpus.
+
+questions:
+  # --- Cat 1: direct factual retrieval (1 hop) ---
+
+  - id: q01_kai_oauth_debug
+    text: "What did Kai debug?"
+    expected_sources:
+      - Kai
+      - OAuth token refresh
+    min_hops: 1
+
+  - id: q02_oauth_spec_topic
+    text: "What is the OAuth token refresh spec about?"
+    expected_sources:
+      - OAuth
+      - token refresh
+    min_hops: 1
+
+  # --- Cat 2c: multi-hop chain A (team → Kai → OAuth → Driftwood) ---
+
+  - id: q03_driftwood_debugger
+    text: "Who debugged the system that blocked the Driftwood migration?"
+    expected_sources:
+      - Kai
+      - Driftwood
+      - OAuth
+    min_hops: 2
+
+  - id: q04_team_member_project
+    text: "What project was affected by the issue debugged by someone on the infrastructure team?"
+    expected_sources:
+      - Driftwood
+      - Kai
+      - infrastructure
+    min_hops: 3
+
+  # --- Cat 3: contradiction detection (auth system) ---
+
+  - id: q05_auth_decision
+    text: "What auth system did the team decide to use?"
+    expected_sources:
+      - Clerk
+      - Auth0
+    min_hops: 1
+
+  # --- Cat 6: temporal evolution (PostgreSQL → SQLite → PostgreSQL) ---
+
+  - id: q06_current_database
+    text: "What database are we using now?"
+    expected_sources:
+      - PostgreSQL
+      - back-to-postgresql
+    min_hops: 1
+
+  - id: q07_database_history
+    text: "What database were we using in session 25?"
+    expected_sources:
+      - SQLite
+      - sqlite-migration
+    min_hops: 1
+
+  # --- Cat 2b: canonicalization (alias pair: ZK proof / zero-knowledge) ---
+
+  - id: q08_privacy_technology
+    text: "What privacy technology is used in identity verification?"
+    expected_sources:
+      - zero-knowledge
+      - ZK proof
+    min_hops: 1
+
+  # --- Cat 5: gap detection (cross-domain token-based identity) ---
+
+  - id: q09_token_identity_cross_domain
+    text: "What topics span auth_engineering and privacy_research?"
+    expected_sources:
+      - token-based identity
+      - privacy
+      - auth
+    min_hops: 2

--- a/tests/test_gap_detection.py
+++ b/tests/test_gap_detection.py
@@ -142,6 +142,37 @@ def test_homology_gracefully_skipped_when_disabled(gap_graph):
     assert report.h1_skipped is False  # we opted out, not "skipped by policy"
 
 
+# --- flat_rarity_mode flagging ----------------------------------------
+
+
+def test_flat_rarity_mode_flagged_when_two_sized_components(gap_graph):
+    """The synthetic_gap_graph fixture has exactly two sized clusters
+    once the isolate is filtered out. The rarity-weighting fallback
+    fires (every shared type weighted 1.0), and the report should
+    flag it so JSON consumers can see why scores are inflated."""
+    entities, edges, _ = gap_graph
+    report = score_gap_detection(entities, edges, run_homology=False)
+    assert report.flat_rarity_mode is True
+
+
+def test_flat_rarity_mode_off_for_no_candidate_pairs():
+    """When there aren't enough sized components to form a pair,
+    flat_rarity_mode stays False — there's nothing to fall back on."""
+    report = score_gap_detection([], [], run_homology=False)
+    assert report.flat_rarity_mode is False
+
+
+def test_flat_rarity_mode_text_in_format_report(gap_graph):
+    """format_report must surface the flag so a maintainer reading the
+    rendered card sees the warning, not just the JSON consumer."""
+    from sme.categories.gap_detection import format_report
+
+    entities, edges, _ = gap_graph
+    report = score_gap_detection(entities, edges, run_homology=False)
+    rendered = format_report(report)
+    assert "flat-rarity mode" in rendered
+
+
 # --- Empty-graph guardrail -------------------------------------------
 
 
@@ -154,3 +185,4 @@ def test_empty_graph_is_all_zeros():
     assert report.isolated_nodes == 0
     assert report.bridges == []
     assert report.candidate_gaps == []
+    assert report.flat_rarity_mode is False

--- a/tests/test_harness_integration.py
+++ b/tests/test_harness_integration.py
@@ -47,6 +47,11 @@ def test_cat9b_empty_manifest_reports_not_applicable():
     assert result.empty_manifest is True
     assert result.total_probes == 0
     assert result.band == "n/a"
+    # call_through_rate must be None on empty manifest — distinct from
+    # "every probe failed" which is the measured 0.0 floor. JSON
+    # consumers reading the rate field without checking empty_manifest
+    # would otherwise see "0%" when the truthful answer is "not measured."
+    assert result.call_through_rate is None
     report = format_cat9b_report(result)
     assert "declared no harness manifest" in report
 


### PR DESCRIPTION
## Summary

Ports five fixes from `techempower-org/multipass-structural-memory-eval#14` (fork issues #5-10) that shipped on the fork but were never PR'd upstream. All are small, self-contained, and independently testable.

- **Cat 9b `None` vs `0.0` semantic fix** — `call_through_rate` now returns `None` when the adapter declares no harness manifest, distinguishing "not measured" from "every probe failed" (`techempower-org/multipass-structural-memory-eval#7`)
- **`flat_rarity_mode` flag on gap detection** — surfaces when the rarity fallback fires on ≤2-sized components, so consumers know scores are in the flat (misleading) regime (`techempower-org/multipass-structural-memory-eval#8`)
- **Spec v8 status caveats** — adds a status banner and 🚧 markers for the 6 CLI commands referenced in the spec but not yet implemented (`techempower-org/multipass-structural-memory-eval#6`)
- **`standard_v0_1/questions.yaml` + `AUTHORING.md`** — reference questions and authoring guide for the starter corpus (`techempower-org/multipass-structural-memory-eval#9`)
- **Version bump `0.0.1` → `0.2.0`** — reflects the actual feature surface after PRs #1-#7 (`techempower-org/multipass-structural-memory-eval#10`, `techempower-org/multipass-structural-memory-eval#5`)

## Test plan

- [x] `pytest tests/test_gap_detection.py tests/test_harness_integration.py -v` — 22 passed, 1 skipped (Betti-1 optional dep)
- [x] `ruff check` on all changed files — clean
- [x] New `flat_rarity_mode` tests: flagging, no-candidates, format-report text
- [x] New Cat 9b test: `test_cat9b_empty_manifest_reports_not_applicable` — verifies `None` return

🫏 Generated with [Claude Code](https://claude.com/claude-code)