### PR TITLE
Cat 4: surface per-ID edge degree in collision report

### DIFF
--- a/sme/categories/ingestion_integrity.py
+++ b/sme/categories/ingestion_integrity.py
@@ -53,6 +53,11 @@ from sme.topology.analyzer import TopologyAnalyzer
 
 log = logging.getLogger(__name__)
 
+# Max per-ID degree lines rendered inside a single collision group before
+# the formatter truncates with a footer. Pathological groups (10+ IDs on the
+# same canonical key) would otherwise blow up the report.
+COLLISION_GROUP_ID_RENDER_LIMIT = 10
+
 
 # --- Canonicalization -------------------------------------------------
 
@@ -284,11 +289,20 @@ def format_report(report: IngestionIntegrityReport) -> str:
         )
         if group.id_degrees:
             max_degree = max(group.id_degrees.values())
-            for eid, deg in sorted(
-                group.id_degrees.items(), key=lambda kv: -kv[1]
-            ):
-                marker = "   ← keep" if deg == max_degree else ""
+            # Deterministic keeper: among IDs tied at max degree, keep the
+            # lexicographically smallest ID so the marker is unique and
+            # stable across runs on the same graph.
+            keeper_id = min(
+                eid for eid, deg in group.id_degrees.items() if deg == max_degree
+            )
+            # Sort by descending degree, tie-broken by ID for determinism.
+            ranked = sorted(group.id_degrees.items(), key=lambda kv: (-kv[1], kv[0]))
+            for eid, deg in ranked[:COLLISION_GROUP_ID_RENDER_LIMIT]:
+                marker = "   ← keep" if eid == keeper_id else ""
                 lines.append(f"                  {eid}  (deg={deg}){marker}")
+            hidden = len(ranked) - COLLISION_GROUP_ID_RENDER_LIMIT
+            if hidden > 0:
+                lines.append(f"                  ... and {hidden} more")
     if len(report.collision_groups) > 5:
         lines.append(
             f"    ... +{len(report.collision_groups) - 5} more collision groups"

--- a/sme/categories/ingestion_integrity.py
+++ b/sme/categories/ingestion_integrity.py
@@ -111,6 +111,11 @@ class CollisionGroup:
     ids: list[str]
     names: list[str]
     entity_type: str
+    # Total degree (in + out edges) per entity ID in the group. When
+    # deduplicating, the highest-degree ID is usually the "real" one —
+    # the canonical entity that other extractions converged on, while
+    # low-degree duplicates are stragglers that missed canonicalization.
+    id_degrees: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -164,6 +169,13 @@ def score_ingestion_integrity(
 
     # --- 4a canonical-collision dedup --------------------------------
 
+    # Degree counter per entity ID — surfaced on collision groups so
+    # operators can tell which ID is the "real" one when deduplicating.
+    degree_by_id: Counter[str] = Counter()
+    for edge in edges:
+        degree_by_id[edge.source_id] += 1
+        degree_by_id[edge.target_id] += 1
+
     key_to_ids: dict[str, list[str]] = defaultdict(list)
     key_to_names: dict[str, list[str]] = defaultdict(list)
     key_to_type: dict[str, str] = {}
@@ -186,6 +198,7 @@ def score_ingestion_integrity(
                     ids=ids,
                     names=key_to_names[key],
                     entity_type=key_to_type[key],
+                    id_degrees={eid: degree_by_id.get(eid, 0) for eid in ids},
                 )
             )
     collision_groups.sort(key=lambda g: len(g.ids), reverse=True)
@@ -267,8 +280,15 @@ def format_report(report: IngestionIntegrityReport) -> str:
             names_preview += f", +{len(group.names) - 4} more"
         lines.append(
             f"    [{group.entity_type}] {names_preview} → "
-            f"{len(group.ids)} distinct IDs"
+            f"{len(group.ids)} distinct IDs:"
         )
+        if group.id_degrees:
+            max_degree = max(group.id_degrees.values())
+            for eid, deg in sorted(
+                group.id_degrees.items(), key=lambda kv: -kv[1]
+            ):
+                marker = "   ← keep" if deg == max_degree else ""
+                lines.append(f"                  {eid}  (deg={deg}){marker}")
     if len(report.collision_groups) > 5:
         lines.append(
             f"    ... +{len(report.collision_groups) - 5} more collision groups"

--- a/sme/topology/fixtures.py
+++ b/sme/topology/fixtures.py
@@ -72,6 +72,9 @@ def synthetic_duplicates_graph() -> tuple[list[Entity], list[Edge], dict]:
         "edge_type_counts": {"RELATED": 6, "MENTIONS": 1, "LINKS_TO": 1},
         "dominant_edge_type": "RELATED",
         "dominant_edge_type_fraction": 6 / 8,
+        # Per-ID degree (in + out) for the Docker collision group. e1
+        # has 4 edges, the rest are unconnected — the keeper is obvious.
+        "collision_id_degrees": {"e1": 4, "e2": 0, "e3": 0, "e4": 0},
     }
 
     return entities, edges, ground_truth

--- a/tests/test_ingestion_integrity.py
+++ b/tests/test_ingestion_integrity.py
@@ -8,6 +8,7 @@ produced for that field is the suspect, not the fixture.
 from __future__ import annotations
 
 from sme.categories.ingestion_integrity import (
+    COLLISION_GROUP_ID_RENDER_LIMIT,
     default_canonical_key,
     format_report,
     score_ingestion_integrity,
@@ -180,3 +181,66 @@ def test_format_report_shows_collision_degree_and_keeper(duplicates_graph):
             line for line in rendered.splitlines() if f"{losing_id}  (deg=0)" in line
         )
         assert "← keep" not in losing_line
+
+
+def test_format_report_truncates_large_collision_group():
+    """A collision group with more than COLLISION_GROUP_ID_RENDER_LIMIT IDs
+    renders the top-N by degree and footer-summarizes the rest."""
+    from sme.adapters.base import Edge, Entity
+
+    n_ids = COLLISION_GROUP_ID_RENDER_LIMIT + 7
+    # All IDs canonicalize to the same key (same name + type).
+    entities = [
+        Entity(id=f"d{i:02d}", name="Docker", entity_type="tool")
+        for i in range(n_ids)
+    ]
+    # Give each ID a distinct degree so ranking is unambiguous: d00 highest.
+    edges = []
+    for i in range(n_ids):
+        for _ in range(n_ids - i):
+            edges.append(
+                Edge(source_id=f"d{i:02d}", target_id="sink", edge_type="uses")
+            )
+
+    report = score_ingestion_integrity(entities, edges)
+    rendered = format_report(report)
+
+    # Exactly the top-N IDs are rendered; the footer accounts for the rest.
+    assert "... and 7 more" in rendered
+    rendered_id_lines = [
+        line for line in rendered.splitlines() if "(deg=" in line
+    ]
+    assert len(rendered_id_lines) == COLLISION_GROUP_ID_RENDER_LIMIT
+    # Highest-degree ID is rendered and kept; a low-rank ID is truncated.
+    assert "d00  (deg=" in rendered
+    assert "d16  (deg=" not in rendered
+
+
+def test_format_report_keeper_is_deterministic_on_tie():
+    """When several IDs tie at the max degree, exactly one is marked the
+    keeper, tie-broken lexicographically on ID for stability across runs."""
+    from sme.adapters.base import Edge, Entity
+
+    # Three IDs canonicalize together; two tie at the max degree.
+    entities = [
+        Entity(id="zeta", name="Docker", entity_type="tool"),
+        Entity(id="alpha", name="Docker", entity_type="tool"),
+        Entity(id="mid", name="Docker", entity_type="tool"),
+    ]
+    # zeta and alpha both have degree 2 (tie at max); mid has degree 1.
+    edges = [
+        Edge(source_id="zeta", target_id="x", edge_type="uses"),
+        Edge(source_id="zeta", target_id="y", edge_type="uses"),
+        Edge(source_id="alpha", target_id="x", edge_type="uses"),
+        Edge(source_id="alpha", target_id="y", edge_type="uses"),
+        Edge(source_id="mid", target_id="x", edge_type="uses"),
+    ]
+
+    report = score_ingestion_integrity(entities, edges)
+    rendered = format_report(report)
+
+    keep_lines = [line for line in rendered.splitlines() if "← keep" in line]
+    assert len(keep_lines) == 1
+    # 'alpha' < 'zeta' lexicographically, so alpha is the deterministic keeper.
+    assert "alpha" in keep_lines[0]
+    assert "zeta" not in keep_lines[0]

--- a/tests/test_ingestion_integrity.py
+++ b/tests/test_ingestion_integrity.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from sme.categories.ingestion_integrity import (
     default_canonical_key,
+    format_report,
     score_ingestion_integrity,
 )
 
@@ -142,3 +143,40 @@ def test_empty_graph_is_all_zeros():
     assert report.required_field_coverage == 1.0
     assert report.edge_type_counts == {}
     assert report.dominant_edge_type is None
+
+
+def test_collision_group_id_degrees_populated(duplicates_graph):
+    """Issue #13 — each collision group surfaces per-ID degree so the
+    operator can tell which ID is the canonical one when deduplicating."""
+    entities, edges, truth = duplicates_graph
+    report = score_ingestion_integrity(entities, edges)
+    tool_docker = [
+        g
+        for g in report.collision_groups
+        if g.entity_type == "tool"
+        and default_canonical_key("Docker", "tool") == g.canonical_key
+    ]
+    assert len(tool_docker) == 1
+    group = tool_docker[0]
+    assert group.id_degrees == truth["collision_id_degrees"]
+
+
+def test_format_report_shows_collision_degree_and_keeper(duplicates_graph):
+    """Issue #13 — the collision-group section should print per-ID degree
+    and mark the highest-degree ID with the '← keep' hint."""
+    entities, edges, _ = duplicates_graph
+    report = score_ingestion_integrity(entities, edges)
+    rendered = format_report(report)
+    # e1 is the only Docker variant with edges (degree 4); the others
+    # are degree 0 stragglers.
+    assert "e1  (deg=4)" in rendered
+    assert "e2  (deg=0)" in rendered
+    assert "← keep" in rendered
+    # The keep marker should be on the e1 line, not on e2/e3/e4.
+    e1_line = next(line for line in rendered.splitlines() if "e1  (deg=4)" in line)
+    assert "← keep" in e1_line
+    for losing_id in ("e2", "e3", "e4"):
+        losing_line = next(
+            line for line in rendered.splitlines() if f"{losing_id}  (deg=0)" in line
+        )
+        assert "← keep" not in losing_line


### PR DESCRIPTION
## Summary

Closes #13.

- Adds `id_degrees: dict[str, int]` field to `CollisionGroup` — total degree (in + out edges) per entity ID in the collision group
- The `format_report()` output now lists each ID with its degree and marks the highest-degree ID with `← keep`
- Degree computation reuses the edge list already passed to `score_ingestion_integrity()` — no additional queries

**Before:**
```
[tool] "Docker", "docker", "DOCKER" → 4 distinct IDs
```

**After:**
```
[tool] "Docker", "docker", "DOCKER" → 4 distinct IDs:
                  e1  (deg=4)   ← keep
                  e2  (deg=0)
                  e3  (deg=0)
                  e4  (deg=0)
```

## Test plan

- [x] New test `test_collision_group_id_degrees_populated` verifies degree dict matches ground truth
- [x] New test `test_format_report_shows_collision_degree_and_keeper` verifies human-readable output
- [x] Existing tests pass unchanged

🫏 Generated with [Claude Code](https://claude.ai/code)