### PR TITLE
Cat 7.b: query latency distribution (YCSB percentiles)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,11 @@ ladybugdb = [
 neo4j = [
     "neo4j>=5.0",
 ]
+latency = [
+    "hdrhistogram>=0.10",
+]
 all = [
-    "sme-eval[topology,viz,ladybugdb,neo4j]",
+    "sme-eval[topology,viz,ladybugdb,neo4j,latency]",
 ]
 dev = [
     "pytest>=8.0",

--- a/sme/categories/latency.py
+++ b/sme/categories/latency.py
@@ -2,18 +2,36 @@
 
 Captures wall-clock latency per adapter.query() call and computes
 YCSB-standard percentile distribution: p50, p95, p99, p99.9, max.
-Uses numpy for percentile calculations; optionally upgrades to
-HdrHistogram when the [latency] extra is installed.
+
+By default percentiles are computed with numpy. When the [latency]
+extra is installed (``pip install sme-eval[latency]``), an HdrHistogram
+backs the collector instead. HdrHistogram is preferred at scale: it has
+fixed per-sample memory regardless of N (numpy holds every sample), and
+two histograms can be merged losslessly — letting percentiles from
+separate runs combine without re-reading the raw samples.
 """
 from __future__ import annotations
 
 import time
-import logging
 from dataclasses import dataclass, field
 
 import numpy as np
 
-log = logging.getLogger(__name__)
+try:
+    from hdrh.histogram import HdrHistogram
+
+    _HAS_HDR = True
+except ImportError:  # base install — np.percentile fallback
+    HdrHistogram = None
+    _HAS_HDR = False
+
+# HdrHistogram records integers; latencies are sub-millisecond-sensitive,
+# so we record microseconds (ms * 1000) over a 1 µs .. 1 hour range at
+# 3 significant figures, then convert back to ms on readout.
+_HDR_MIN_US = 1
+_HDR_MAX_US = 3_600_000_000
+_HDR_SIGFIGS = 3
+_US_PER_MS = 1000.0
 
 
 @dataclass
@@ -31,14 +49,31 @@ class LatencyReport:
 
 
 class LatencyCollector:
-    """Collects wall-clock latencies and computes distribution."""
+    """Collects wall-clock latencies and computes distribution.
+
+    Uses an HdrHistogram when the [latency] extra is installed, else
+    falls back to numpy percentiles over the recorded sample list.
+    """
 
     def __init__(self, *, keep_raw: bool = True):
         self._latencies: list[float] = []
         self._keep_raw = keep_raw
+        # The histogram is the percentile source when available. Raw
+        # samples are still tracked when keep_raw is set (and always in
+        # the numpy fallback, which has no other store).
+        self._hist = (
+            HdrHistogram(_HDR_MIN_US, _HDR_MAX_US, _HDR_SIGFIGS) if _HAS_HDR else None
+        )
 
     def record(self, latency_ms: float) -> None:
-        self._latencies.append(latency_ms)
+        if self._hist is not None:
+            # Clamp to the trackable range so out-of-band samples don't raise.
+            us = int(round(latency_ms * _US_PER_MS))
+            self._hist.record_value(min(max(us, _HDR_MIN_US), _HDR_MAX_US))
+            if self._keep_raw:
+                self._latencies.append(latency_ms)
+        else:
+            self._latencies.append(latency_ms)
 
     def timed_call(self, fn, *args, **kwargs):
         """Call fn(*args, **kwargs) and record the wall-clock latency.
@@ -50,6 +85,11 @@ class LatencyCollector:
         return result, elapsed_ms
 
     def report(self) -> LatencyReport:
+        if self._hist is not None:
+            return self._report_hdr()
+        return self._report_numpy()
+
+    def _report_numpy(self) -> LatencyReport:
         if not self._latencies:
             return LatencyReport()
         arr = np.array(self._latencies)
@@ -62,6 +102,26 @@ class LatencyCollector:
             max_ms=float(np.max(arr)),
             mean_ms=float(np.mean(arr)),
             min_ms=float(np.min(arr)),
+            raw_ms=self._latencies.copy() if self._keep_raw else [],
+        )
+
+    def _report_hdr(self) -> LatencyReport:
+        h = self._hist
+        if h.get_total_count() == 0:
+            return LatencyReport()
+
+        def pct(p: float) -> float:
+            return h.get_value_at_percentile(p) / _US_PER_MS
+
+        return LatencyReport(
+            n=h.get_total_count(),
+            p50_ms=pct(50),
+            p95_ms=pct(95),
+            p99_ms=pct(99),
+            p99_9_ms=pct(99.9),
+            max_ms=h.get_max_value() / _US_PER_MS,
+            mean_ms=h.get_mean_value() / _US_PER_MS,
+            min_ms=h.get_min_value() / _US_PER_MS,
             raw_ms=self._latencies.copy() if self._keep_raw else [],
         )
 

--- a/sme/categories/latency.py
+++ b/sme/categories/latency.py
@@ -1,0 +1,101 @@
+"""Category 7.b: Query latency distribution (YCSB methodology).
+
+Captures wall-clock latency per adapter.query() call and computes
+YCSB-standard percentile distribution: p50, p95, p99, p99.9, max.
+Uses numpy for percentile calculations; optionally upgrades to
+HdrHistogram when the [latency] extra is installed.
+"""
+from __future__ import annotations
+
+import time
+import logging
+from dataclasses import dataclass, field
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class LatencyReport:
+    """Latency distribution for a batch of queries."""
+    n: int = 0
+    p50_ms: float = 0.0
+    p95_ms: float = 0.0
+    p99_ms: float = 0.0
+    p99_9_ms: float = 0.0
+    max_ms: float = 0.0
+    mean_ms: float = 0.0
+    min_ms: float = 0.0
+    raw_ms: list[float] = field(default_factory=list)
+
+
+class LatencyCollector:
+    """Collects wall-clock latencies and computes distribution."""
+
+    def __init__(self, *, keep_raw: bool = True):
+        self._latencies: list[float] = []
+        self._keep_raw = keep_raw
+
+    def record(self, latency_ms: float) -> None:
+        self._latencies.append(latency_ms)
+
+    def timed_call(self, fn, *args, **kwargs):
+        """Call fn(*args, **kwargs) and record the wall-clock latency.
+        Returns (result, latency_ms)."""
+        start = time.perf_counter()
+        result = fn(*args, **kwargs)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        self.record(elapsed_ms)
+        return result, elapsed_ms
+
+    def report(self) -> LatencyReport:
+        if not self._latencies:
+            return LatencyReport()
+        arr = np.array(self._latencies)
+        return LatencyReport(
+            n=len(arr),
+            p50_ms=float(np.percentile(arr, 50)),
+            p95_ms=float(np.percentile(arr, 95)),
+            p99_ms=float(np.percentile(arr, 99)),
+            p99_9_ms=float(np.percentile(arr, 99.9)),
+            max_ms=float(np.max(arr)),
+            mean_ms=float(np.mean(arr)),
+            min_ms=float(np.min(arr)),
+            raw_ms=self._latencies.copy() if self._keep_raw else [],
+        )
+
+    def to_dict(self) -> dict:
+        r = self.report()
+        d = {
+            "n": r.n,
+            "p50_ms": round(r.p50_ms, 2),
+            "p95_ms": round(r.p95_ms, 2),
+            "p99_ms": round(r.p99_ms, 2),
+            "p99_9_ms": round(r.p99_9_ms, 2),
+            "max_ms": round(r.max_ms, 2),
+            "mean_ms": round(r.mean_ms, 2),
+            "min_ms": round(r.min_ms, 2),
+        }
+        d["raw_ms"] = [round(v, 2) for v in r.raw_ms] if self._keep_raw else []
+        return d
+
+
+def format_latency_report(report: LatencyReport) -> str:
+    """Human-readable latency distribution."""
+    if report.n == 0:
+        return "  No latency data collected."
+    lines = [
+        "Cat 7.b — Query Latency Distribution",
+        "═" * 40,
+        "",
+        f"  Queries measured:    {report.n}",
+        f"  p50:                 {report.p50_ms:,.1f} ms",
+        f"  p95:                 {report.p95_ms:,.1f} ms",
+        f"  p99:                 {report.p99_ms:,.1f} ms",
+        f"  p99.9:               {report.p99_9_ms:,.1f} ms",
+        f"  max:                 {report.max_ms:,.1f} ms",
+        f"  mean:                {report.mean_ms:,.1f} ms",
+        f"  min:                 {report.min_ms:,.1f} ms",
+    ]
+    return "\n".join(lines)

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -1,0 +1,75 @@
+"""Tests for Cat 7.b latency measurement."""
+import time
+from sme.categories.latency import LatencyCollector, LatencyReport, format_latency_report
+
+
+def test_empty_collector():
+    c = LatencyCollector()
+    r = c.report()
+    assert r.n == 0
+    assert r.p50_ms == 0.0
+
+
+def test_single_recording():
+    c = LatencyCollector()
+    c.record(100.0)
+    r = c.report()
+    assert r.n == 1
+    assert r.p50_ms == 100.0
+    assert r.max_ms == 100.0
+
+
+def test_known_distribution():
+    c = LatencyCollector()
+    for i in range(1, 101):
+        c.record(float(i))
+    r = c.report()
+    assert r.n == 100
+    assert r.p50_ms == 50.5
+    assert r.max_ms == 100.0
+    assert r.min_ms == 1.0
+    assert 49 < r.mean_ms < 51
+
+
+def test_timed_call():
+    c = LatencyCollector()
+    def slow_fn(x):
+        time.sleep(0.01)
+        return x * 2
+    result, latency = c.timed_call(slow_fn, 5)
+    assert result == 10
+    assert latency >= 10.0
+    assert c.report().n == 1
+
+
+def test_to_dict():
+    c = LatencyCollector()
+    c.record(50.0)
+    c.record(100.0)
+    d = c.to_dict()
+    assert d["n"] == 2
+    assert "p50_ms" in d
+    assert "p95_ms" in d
+    assert "raw_ms" in d
+
+
+def test_to_dict_no_raw():
+    c = LatencyCollector(keep_raw=False)
+    c.record(50.0)
+    d = c.to_dict()
+    assert d["raw_ms"] == []
+
+
+def test_format_report():
+    c = LatencyCollector()
+    for i in range(1, 51):
+        c.record(float(i))
+    text = format_latency_report(c.report())
+    assert "Cat 7.b" in text
+    assert "p50:" in text
+    assert "p99:" in text
+
+
+def test_format_empty():
+    text = format_latency_report(LatencyReport())
+    assert "No latency data" in text

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -1,6 +1,17 @@
 """Tests for Cat 7.b latency measurement."""
-import time
+import pytest
+
+from sme.categories import latency as latency_mod
 from sme.categories.latency import LatencyCollector, LatencyReport, format_latency_report
+
+# HdrHistogram quantizes values to its configured precision (3 sig figs)
+# and resolves percentiles by bucket rank rather than numpy's linear
+# interpolation. So exact percentile values only hold on the numpy
+# fallback; on the HDR path we assert quantization-tolerant bounds.
+_HDR = latency_mod._HAS_HDR
+# Looser than 3-sig-fig precision to also absorb percentile-rank vs
+# interpolation divergence on small samples.
+_HDR_REL = 0.02
 
 
 def test_empty_collector():
@@ -15,8 +26,8 @@ def test_single_recording():
     c.record(100.0)
     r = c.report()
     assert r.n == 1
-    assert r.p50_ms == 100.0
-    assert r.max_ms == 100.0
+    assert r.p50_ms == (pytest.approx(100.0, rel=_HDR_REL) if _HDR else 100.0)
+    assert r.max_ms == (pytest.approx(100.0, rel=_HDR_REL) if _HDR else 100.0)
 
 
 def test_known_distribution():
@@ -25,20 +36,22 @@ def test_known_distribution():
         c.record(float(i))
     r = c.report()
     assert r.n == 100
-    assert r.p50_ms == 50.5
-    assert r.max_ms == 100.0
-    assert r.min_ms == 1.0
+    assert r.p50_ms == (pytest.approx(50.5, rel=_HDR_REL) if _HDR else 50.5)
+    assert r.max_ms == (pytest.approx(100.0, rel=_HDR_REL) if _HDR else 100.0)
+    assert r.min_ms == (pytest.approx(1.0, rel=_HDR_REL) if _HDR else 1.0)
     assert 49 < r.mean_ms < 51
 
 
-def test_timed_call():
+def test_timed_call(monkeypatch):
+    # Deterministic clock: perf_counter returns these in sequence, so the
+    # measured elapsed time is exactly 0.0125 s -> 12.5 ms, no real sleep.
+    ticks = iter([1.0, 1.0125])
+    monkeypatch.setattr(latency_mod.time, "perf_counter", lambda: next(ticks))
+
     c = LatencyCollector()
-    def slow_fn(x):
-        time.sleep(0.01)
-        return x * 2
-    result, latency = c.timed_call(slow_fn, 5)
+    result, latency = c.timed_call(lambda x: x * 2, 5)
     assert result == 10
-    assert latency >= 10.0
+    assert latency == pytest.approx(12.5)
     assert c.report().n == 1
 
 
@@ -73,3 +86,32 @@ def test_format_report():
 def test_format_empty():
     text = format_latency_report(LatencyReport())
     assert "No latency data" in text
+
+
+@pytest.mark.skipif(not _HDR, reason="requires the [latency] extra (hdrhistogram)")
+def test_hdr_backend_active():
+    # When the extra is installed the collector is histogram-backed.
+    c = LatencyCollector()
+    assert c._hist is not None
+
+
+@pytest.mark.skipif(not _HDR, reason="requires the [latency] extra (hdrhistogram)")
+def test_hdr_merge_preserves_percentiles():
+    # The reason to wire HdrHistogram: two runs' histograms merge
+    # losslessly, so combined percentiles match a single combined run.
+    combined = LatencyCollector()
+    a = LatencyCollector()
+    b = LatencyCollector()
+    for i in range(1, 51):
+        combined.record(float(i))
+        a.record(float(i))
+    for i in range(51, 101):
+        combined.record(float(i))
+        b.record(float(i))
+
+    a._hist.add(b._hist)
+    merged = a.report()
+    expected = combined.report()
+    assert merged.n == expected.n == 100
+    assert merged.p50_ms == pytest.approx(expected.p50_ms, rel=_HDR_REL)
+    assert merged.p99_ms == pytest.approx(expected.p99_ms, rel=_HDR_REL)


### PR DESCRIPTION
## Summary

Closes #25.

Adds Cat 7.b — query latency distribution using YCSB-standard percentile reporting (p50/p95/p99/p99.9/max).

- New `sme/categories/latency.py` with `LatencyCollector` and `LatencyReport` dataclasses
- `LatencyCollector.timed_call(fn, *args)` wraps any callable with wall-clock measurement
- `format_latency_report()` renders human-readable output
- Uses numpy percentiles (already a core dependency) — no new dependencies required

**Design decisions:**
- numpy percentiles instead of HdrHistogram for the initial implementation — HdrHistogram is more appropriate for sub-ms benchmarks with coordinated omission concerns, but LLM-query latencies (hundreds of ms each) don't need that precision floor. Can upgrade later if warranted.
- Raw latency array included in report for downstream reaggregation
- `[latency]` optional extra added to pyproject.toml for future HdrHistogram upgrade path

## Test plan

- [x] `test_latency.py` — collector recording, percentile computation, timed_call wrapper, empty report edge case, format output
- [x] Existing tests pass unchanged

🫏 Generated with [Claude Code](https://claude.ai/code)