### PR TITLE
Cost-per-correct headline metric with versioned pricing (HELM methodology)

### DIFF
--- a/sme/eval/pricing.py
+++ b/sme/eval/pricing.py
@@ -1,0 +1,92 @@
+"""Versioned model pricing for cost-per-correct computation (HELM methodology).
+
+Pricing tables are YAML files at sme/eval/pricing_YYYY_MM.yaml.
+Each table maps model identifiers to $/1M token rates for input
+and output. Tables are versioned by date because pricing drifts.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+PRICING_DIR = Path(__file__).parent
+
+
+@dataclass
+class ModelPricing:
+    """Per-model pricing in USD per 1M tokens."""
+    model_id: str
+    input_per_1m: float
+    output_per_1m: float
+
+    def cost_for_tokens(self, input_tokens: int, output_tokens: int) -> float:
+        return (
+            (input_tokens / 1_000_000) * self.input_per_1m
+            + (output_tokens / 1_000_000) * self.output_per_1m
+        )
+
+
+@dataclass
+class PricingTable:
+    """A versioned pricing table."""
+    version: str
+    models: dict[str, ModelPricing]
+
+    def get(self, model_id: str) -> Optional[ModelPricing]:
+        return self.models.get(model_id)
+
+    def cost_for_tokens(self, model_id: str, input_tokens: int, output_tokens: int) -> Optional[float]:
+        pricing = self.get(model_id)
+        if pricing is None:
+            return None
+        return pricing.cost_for_tokens(input_tokens, output_tokens)
+
+
+def load_pricing_table(version: str = "2026_05") -> PricingTable:
+    """Load a versioned pricing table from YAML."""
+    path = PRICING_DIR / f"pricing_{version}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"pricing table not found: {path}. "
+            f"Available: {[p.stem for p in PRICING_DIR.glob('pricing_*.yaml')]}"
+        )
+    raw = yaml.safe_load(path.read_text())
+    models = {}
+    for model_id, rates in raw.get("models", {}).items():
+        models[model_id] = ModelPricing(
+            model_id=model_id,
+            input_per_1m=float(rates.get("input_per_1m", 0)),
+            output_per_1m=float(rates.get("output_per_1m", 0)),
+        )
+    return PricingTable(version=version, models=models)
+
+
+def cost_per_correct(
+    total_cost_usd: float,
+    correct_count: int,
+    total_count: int,
+) -> dict:
+    """Compute cost-per-correct headline metric.
+
+    Returns:
+        {
+            "total_cost_usd": float,
+            "correct_count": int,
+            "total_count": int,
+            "cost_per_correct_usd": float or None (if 0 correct),
+            "cost_per_query_usd": float,
+        }
+    """
+    return {
+        "total_cost_usd": round(total_cost_usd, 6),
+        "correct_count": correct_count,
+        "total_count": total_count,
+        "cost_per_correct_usd": round(total_cost_usd / correct_count, 6) if correct_count > 0 else None,
+        "cost_per_query_usd": round(total_cost_usd / total_count, 6) if total_count > 0 else 0.0,
+    }

--- a/sme/eval/pricing.py
+++ b/sme/eval/pricing.py
@@ -57,6 +57,12 @@ def load_pricing_table(version: str = "2026_05") -> PricingTable:
             f"Available: {[p.stem for p in PRICING_DIR.glob('pricing_*.yaml')]}"
         )
     raw = yaml.safe_load(path.read_text())
+    declared_version = raw.get("version")
+    if declared_version is not None and declared_version != version:
+        raise ValueError(
+            f"pricing table version mismatch: requested {version!r} "
+            f"but {path.name} declares {declared_version!r}"
+        )
     models = {}
     for model_id, rates in raw.get("models", {}).items():
         models[model_id] = ModelPricing(
@@ -64,7 +70,7 @@ def load_pricing_table(version: str = "2026_05") -> PricingTable:
             input_per_1m=float(rates.get("input_per_1m", 0)),
             output_per_1m=float(rates.get("output_per_1m", 0)),
         )
-    return PricingTable(version=version, models=models)
+    return PricingTable(version=declared_version or version, models=models)
 
 
 def cost_per_correct(

--- a/sme/eval/pricing_2026_05.yaml
+++ b/sme/eval/pricing_2026_05.yaml
@@ -1,0 +1,49 @@
+# SME pricing table — May 2026 snapshot
+# Source: public pricing pages as of 2026-05-01
+# All values in USD per 1 million tokens
+version: "2026_05"
+
+models:
+  # OpenAI
+  gpt-4o-2024-08-06:
+    input_per_1m: 2.50
+    output_per_1m: 10.00
+  gpt-4o-mini:
+    input_per_1m: 0.15
+    output_per_1m: 0.60
+  gpt-4o:
+    input_per_1m: 2.50
+    output_per_1m: 10.00
+  o1:
+    input_per_1m: 15.00
+    output_per_1m: 60.00
+  o4-mini:
+    input_per_1m: 1.10
+    output_per_1m: 4.40
+
+  # Anthropic
+  claude-sonnet-4-6:
+    input_per_1m: 3.00
+    output_per_1m: 15.00
+  claude-opus-4-6:
+    input_per_1m: 15.00
+    output_per_1m: 75.00
+  claude-haiku-4-5:
+    input_per_1m: 0.80
+    output_per_1m: 4.00
+
+  # Open-source (typical API endpoint pricing)
+  llama-3.1-70b:
+    input_per_1m: 0.35
+    output_per_1m: 0.40
+  llama-3.1-8b:
+    input_per_1m: 0.05
+    output_per_1m: 0.08
+  qwen-2.5-7b:
+    input_per_1m: 0.05
+    output_per_1m: 0.08
+
+  # Local (zero cost — amortized hardware not tracked)
+  local:
+    input_per_1m: 0.0
+    output_per_1m: 0.0

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,5 +1,5 @@
 """Tests for pricing table and cost-per-correct computation."""
-from sme.eval.pricing import load_pricing_table, cost_per_correct, ModelPricing, PricingTable
+from sme.eval.pricing import load_pricing_table, cost_per_correct, ModelPricing
 import pytest
 
 def test_load_default_pricing_table():
@@ -32,8 +32,8 @@ def test_pricing_table_cost_for_tokens():
 
 def test_cost_per_correct_basic():
     result = cost_per_correct(1.0, 10, 100)
-    assert result["cost_per_correct_usd"] == 0.1
-    assert result["cost_per_query_usd"] == 0.01
+    assert result["cost_per_correct_usd"] == pytest.approx(0.1)
+    assert result["cost_per_query_usd"] == pytest.approx(0.01)
 
 def test_cost_per_correct_zero_correct():
     result = cost_per_correct(1.0, 0, 100)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,53 @@
+"""Tests for pricing table and cost-per-correct computation."""
+from sme.eval.pricing import load_pricing_table, cost_per_correct, ModelPricing, PricingTable
+import pytest
+
+def test_load_default_pricing_table():
+    table = load_pricing_table("2026_05")
+    assert table.version == "2026_05"
+    assert len(table.models) > 0
+
+def test_model_pricing_cost():
+    p = ModelPricing("test", input_per_1m=2.0, output_per_1m=10.0)
+    # 1M input + 1M output = $2 + $10 = $12
+    assert p.cost_for_tokens(1_000_000, 1_000_000) == 12.0
+    # 500K input + 0 output = $1
+    assert p.cost_for_tokens(500_000, 0) == 1.0
+
+def test_pricing_table_get():
+    table = load_pricing_table("2026_05")
+    gpt4o = table.get("gpt-4o")
+    assert gpt4o is not None
+    assert gpt4o.input_per_1m > 0
+
+def test_pricing_table_unknown_model():
+    table = load_pricing_table("2026_05")
+    assert table.get("nonexistent-model") is None
+
+def test_pricing_table_cost_for_tokens():
+    table = load_pricing_table("2026_05")
+    cost = table.cost_for_tokens("gpt-4o-mini", 100_000, 50_000)
+    assert cost is not None
+    assert cost > 0
+
+def test_cost_per_correct_basic():
+    result = cost_per_correct(1.0, 10, 100)
+    assert result["cost_per_correct_usd"] == 0.1
+    assert result["cost_per_query_usd"] == 0.01
+
+def test_cost_per_correct_zero_correct():
+    result = cost_per_correct(1.0, 0, 100)
+    assert result["cost_per_correct_usd"] is None
+
+def test_cost_per_correct_zero_total():
+    result = cost_per_correct(0.0, 0, 0)
+    assert result["cost_per_query_usd"] == 0.0
+
+def test_load_nonexistent_version():
+    with pytest.raises(FileNotFoundError):
+        load_pricing_table("1999_01")
+
+def test_local_model_zero_cost():
+    table = load_pricing_table("2026_05")
+    cost = table.cost_for_tokens("local", 1_000_000, 1_000_000)
+    assert cost == 0.0


### PR DESCRIPTION
## Summary

Closes #26.

Adds cost-per-correct computation following HELM methodology (Liang et al. 2022):

- **`sme/eval/pricing.py`** — `PricingTable`, `ModelPricing`, `cost_per_correct()` with versioned pricing table loading
- **`sme/eval/pricing_2026_05.yaml`** — May 2026 pricing snapshot covering OpenAI (gpt-4o, o1, o4-mini), Anthropic (Claude Opus/Sonnet/Haiku), open-source endpoints (Llama 3.1, Qwen 2.5), and local (zero-cost)
- `cost_per_correct()` returns `total_cost_usd`, `cost_per_correct_usd`, `cost_per_query_usd`

**Design decisions:**
- Pricing tables are versioned YAML files (`pricing_YYYY_MM.yaml`) per HELM convention — pricing drifts, so re-runs must declare which table they used
- No new dependencies (yaml is already a core dep)
- `cost_estimator()` ABC method deferred to follow-up — this PR provides the computation engine; adapter integration comes separately
- Local models priced at $0 — amortized hardware cost tracking is out of scope

## Test plan

- [x] `test_pricing.py` — table loading, model lookup, cost computation, missing model handling, zero-correct edge case
- [x] Existing tests pass unchanged

🫏 Generated with [Claude Code](https://claude.ai/code)