### PR TITLE
Paired bootstrap CIs and Benjamini-Hochberg FDR correction

### DIFF
--- a/sme/stats/__init__.py
+++ b/sme/stats/__init__.py
@@ -1,0 +1,10 @@
+"""Statistical testing utilities for SME (bootstrap CIs, FDR correction)."""
+from sme.stats.bootstrap import BootstrapCIResult, paired_bootstrap_ci
+from sme.stats.fdr import FDRResult, benjamini_hochberg
+
+__all__ = [
+    "BootstrapCIResult",
+    "FDRResult",
+    "benjamini_hochberg",
+    "paired_bootstrap_ci",
+]

--- a/sme/stats/bootstrap.py
+++ b/sme/stats/bootstrap.py
@@ -18,7 +18,7 @@ class BootstrapCIResult:
     ci_upper: float
     n_bootstrap: int
     confidence_level: float
-    p_value_approx: float  # fraction of bootstrap diffs crossing zero
+    p_value_approx: float  # two-sided: 2x the fraction of bootstrap means on the opposite side of zero (capped at 1.0)
 
 
 def paired_bootstrap_ci(
@@ -41,7 +41,10 @@ def paired_bootstrap_ci(
     Returns:
         BootstrapCIResult with mean difference and CI bounds
     """
-    assert len(scores_a) == len(scores_b), "Paired scores must be same length"
+    if len(scores_a) != len(scores_b):
+        raise ValueError(
+            f"Paired scores must be same length: got {len(scores_a)} and {len(scores_b)}"
+        )
     rng = np.random.RandomState(seed)
     a = np.array(scores_a, dtype=float)
     b = np.array(scores_b, dtype=float)

--- a/sme/stats/bootstrap.py
+++ b/sme/stats/bootstrap.py
@@ -1,0 +1,74 @@
+"""Paired bootstrap confidence intervals (Efron & Tibshirani 1993).
+
+Standard non-parametric CI for per-question paired differences.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class BootstrapCIResult:
+    """Result of a paired bootstrap CI computation."""
+
+    mean_diff: float
+    ci_lower: float
+    ci_upper: float
+    n_bootstrap: int
+    confidence_level: float
+    p_value_approx: float  # fraction of bootstrap diffs crossing zero
+
+
+def paired_bootstrap_ci(
+    scores_a: list[float],
+    scores_b: list[float],
+    *,
+    n_bootstrap: int = 10000,
+    confidence: float = 0.95,
+    seed: int = 42,
+) -> BootstrapCIResult:
+    """Paired bootstrap CI on per-item score differences.
+
+    Args:
+        scores_a: Per-item scores for condition A
+        scores_b: Per-item scores for condition B (same length, paired)
+        n_bootstrap: Number of bootstrap resamples
+        confidence: Confidence level (default 0.95 for 95% CI)
+        seed: RNG seed for reproducibility
+
+    Returns:
+        BootstrapCIResult with mean difference and CI bounds
+    """
+    assert len(scores_a) == len(scores_b), "Paired scores must be same length"
+    rng = np.random.RandomState(seed)
+    a = np.array(scores_a, dtype=float)
+    b = np.array(scores_b, dtype=float)
+    diffs = a - b
+    observed_mean = float(np.mean(diffs))
+    n = len(diffs)
+
+    boot_means = np.empty(n_bootstrap)
+    for i in range(n_bootstrap):
+        indices = rng.randint(0, n, size=n)
+        boot_means[i] = np.mean(diffs[indices])
+
+    alpha = 1.0 - confidence
+    ci_lower = float(np.percentile(boot_means, 100 * alpha / 2))
+    ci_upper = float(np.percentile(boot_means, 100 * (1 - alpha / 2)))
+
+    if observed_mean >= 0:
+        p_approx = float(np.mean(boot_means < 0))
+    else:
+        p_approx = float(np.mean(boot_means > 0))
+    p_approx = min(2 * p_approx, 1.0)
+
+    return BootstrapCIResult(
+        mean_diff=observed_mean,
+        ci_lower=ci_lower,
+        ci_upper=ci_upper,
+        n_bootstrap=n_bootstrap,
+        confidence_level=confidence,
+        p_value_approx=p_approx,
+    )

--- a/sme/stats/fdr.py
+++ b/sme/stats/fdr.py
@@ -30,11 +30,18 @@ def benjamini_hochberg(
     Returns:
         FDRResult with adjusted p-values and rejection decisions
     """
+    if not (0.0 < alpha <= 1.0):
+        raise ValueError(f"alpha must be in (0, 1], got {alpha}")
+
     m = len(p_values)
     if m == 0:
         return FDRResult([], [], [], alpha)
 
     pv = np.array(p_values, dtype=float)
+    if np.isnan(pv).any():
+        raise ValueError("p_values must not contain NaN")
+    if ((pv < 0.0) | (pv > 1.0)).any():
+        raise ValueError("p_values must all be in [0, 1]")
     sorted_idx = np.argsort(pv)
     sorted_pv = pv[sorted_idx]
 

--- a/sme/stats/fdr.py
+++ b/sme/stats/fdr.py
@@ -1,0 +1,56 @@
+"""Benjamini-Hochberg FDR correction for multiple comparisons."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class FDRResult:
+    """Result of BH-FDR correction."""
+
+    original_p_values: list[float]
+    adjusted_p_values: list[float]
+    rejected: list[bool]  # True = significant after correction
+    alpha: float
+
+
+def benjamini_hochberg(
+    p_values: list[float],
+    *,
+    alpha: float = 0.05,
+) -> FDRResult:
+    """Benjamini-Hochberg FDR correction.
+
+    Args:
+        p_values: Raw p-values from multiple tests
+        alpha: FDR threshold (default 0.05)
+
+    Returns:
+        FDRResult with adjusted p-values and rejection decisions
+    """
+    m = len(p_values)
+    if m == 0:
+        return FDRResult([], [], [], alpha)
+
+    pv = np.array(p_values, dtype=float)
+    sorted_idx = np.argsort(pv)
+    sorted_pv = pv[sorted_idx]
+
+    adjusted = np.empty(m)
+    adjusted[sorted_idx[-1]] = sorted_pv[-1]
+    for i in range(m - 2, -1, -1):
+        rank = i + 1
+        adj = sorted_pv[i] * m / rank
+        adjusted[sorted_idx[i]] = min(adj, adjusted[sorted_idx[i + 1]])
+
+    adjusted = np.minimum(adjusted, 1.0)
+    rejected = adjusted <= alpha
+
+    return FDRResult(
+        original_p_values=p_values,
+        adjusted_p_values=adjusted.tolist(),
+        rejected=rejected.tolist(),
+        alpha=alpha,
+    )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,69 @@
+"""Tests for sme/stats/ — bootstrap CI and FDR correction."""
+from __future__ import annotations
+
+import pytest
+
+from sme.stats.bootstrap import paired_bootstrap_ci
+from sme.stats.fdr import benjamini_hochberg
+
+
+class TestPairedBootstrapCI:
+    def test_identical_scores_zero_diff(self):
+        """Identical paired scores should give CI containing zero."""
+        scores = [0.8, 0.6, 0.7, 0.9, 0.5]
+        result = paired_bootstrap_ci(scores, scores)
+        assert result.mean_diff == 0.0
+        assert result.ci_lower <= 0.0 <= result.ci_upper
+
+    def test_clear_winner_positive_ci(self):
+        """When A clearly beats B, CI should be entirely positive."""
+        a = [1.0] * 50
+        b = [0.0] * 50
+        result = paired_bootstrap_ci(a, b)
+        assert result.mean_diff == 1.0
+        assert result.ci_lower > 0.0
+        assert result.p_value_approx < 0.05
+
+    def test_seed_determinism(self):
+        """Same seed should give identical results."""
+        a = [0.8, 0.6, 0.7, 0.9, 0.5, 0.4, 0.8, 0.7, 0.6, 0.5]
+        b = [0.5, 0.4, 0.6, 0.7, 0.3, 0.2, 0.6, 0.5, 0.4, 0.3]
+        r1 = paired_bootstrap_ci(a, b, seed=123)
+        r2 = paired_bootstrap_ci(a, b, seed=123)
+        assert r1.mean_diff == r2.mean_diff
+        assert r1.ci_lower == r2.ci_lower
+        assert r1.ci_upper == r2.ci_upper
+
+    def test_mismatched_lengths_raises(self):
+        with pytest.raises(AssertionError):
+            paired_bootstrap_ci([1, 2, 3], [1, 2])
+
+
+class TestBenjaminiHochberg:
+    def test_no_pvalues(self):
+        result = benjamini_hochberg([])
+        assert result.adjusted_p_values == []
+        assert result.rejected == []
+
+    def test_all_significant(self):
+        """Very small p-values should all survive correction."""
+        result = benjamini_hochberg([0.001, 0.002, 0.003])
+        assert all(result.rejected)
+
+    def test_mixed_significance(self):
+        """Mix of significant and non-significant p-values.
+
+        For [0.01, 0.04, 0.5, 0.8] with m=4 and alpha=0.05, BH-adjusted
+        p-values are [0.04, 0.08, 0.667, 0.8] — only the first survives.
+        """
+        result = benjamini_hochberg([0.01, 0.04, 0.5, 0.8])
+        assert result.rejected[0] is True
+        assert result.rejected[2] is False
+        assert result.rejected[3] is False
+
+    def test_adjusted_monotonic_with_original_order(self):
+        """Adjusted p-values should never be less than originals."""
+        pvals = [0.01, 0.03, 0.05, 0.1, 0.5]
+        result = benjamini_hochberg(pvals)
+        for orig, adj in zip(pvals, result.adjusted_p_values):
+            assert adj >= orig or abs(adj - orig) < 1e-10

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -19,7 +19,7 @@ class TestPairedBootstrapCI:
         """When A clearly beats B, CI should be entirely positive."""
         a = [1.0] * 50
         b = [0.0] * 50
-        result = paired_bootstrap_ci(a, b)
+        result = paired_bootstrap_ci(a, b, n_bootstrap=200)
         assert result.mean_diff == 1.0
         assert result.ci_lower > 0.0
         assert result.p_value_approx < 0.05
@@ -28,14 +28,19 @@ class TestPairedBootstrapCI:
         """Same seed should give identical results."""
         a = [0.8, 0.6, 0.7, 0.9, 0.5, 0.4, 0.8, 0.7, 0.6, 0.5]
         b = [0.5, 0.4, 0.6, 0.7, 0.3, 0.2, 0.6, 0.5, 0.4, 0.3]
-        r1 = paired_bootstrap_ci(a, b, seed=123)
-        r2 = paired_bootstrap_ci(a, b, seed=123)
+        r1 = paired_bootstrap_ci(a, b, seed=123, n_bootstrap=200)
+        r2 = paired_bootstrap_ci(a, b, seed=123, n_bootstrap=200)
         assert r1.mean_diff == r2.mean_diff
         assert r1.ci_lower == r2.ci_lower
         assert r1.ci_upper == r2.ci_upper
 
     def test_mismatched_lengths_raises(self):
-        with pytest.raises(AssertionError):
+        """Mismatched lengths must raise ValueError, not a bare assert.
+
+        Asserts are stripped under `python -O`, which would silently
+        skip this validation in optimized deployments.
+        """
+        with pytest.raises(ValueError):
             paired_bootstrap_ci([1, 2, 3], [1, 2])
 
 
@@ -67,3 +72,17 @@ class TestBenjaminiHochberg:
         result = benjamini_hochberg(pvals)
         for orig, adj in zip(pvals, result.adjusted_p_values):
             assert adj >= orig or abs(adj - orig) < 1e-10
+
+    @pytest.mark.parametrize("bad", [-0.01, 1.01])
+    def test_pvalue_out_of_range_raises(self, bad):
+        with pytest.raises(ValueError):
+            benjamini_hochberg([0.01, bad, 0.5])
+
+    def test_pvalue_nan_raises(self):
+        with pytest.raises(ValueError):
+            benjamini_hochberg([0.01, float("nan"), 0.5])
+
+    @pytest.mark.parametrize("bad_alpha", [0.0, -0.1, 1.5])
+    def test_alpha_out_of_range_raises(self, bad_alpha):
+        with pytest.raises(ValueError):
+            benjamini_hochberg([0.01, 0.04], alpha=bad_alpha)


### PR DESCRIPTION
## Summary

Closes #21.

Adds a `sme/stats/` module with two standard statistical testing tools:

- **`paired_bootstrap_ci()`** — non-parametric confidence interval on per-question paired differences between conditions (Efron & Tibshirani 1993). Seeded for reproducibility. Reports mean difference, CI bounds, and approximate two-tailed p-value.
- **`benjamini_hochberg()`** — BH-FDR correction for multiple comparisons when testing across many categories. Returns adjusted p-values and rejection decisions.

**Design decisions:**
- Pure numpy implementation (already a core dep) — no scipy dependency needed
- Seed-deterministic bootstrap for reproducible CI reports
- P-value approximation via bootstrap distribution (fraction crossing zero, two-tailed)

## Test plan

- [x] `tests/test_stats.py` — covers:
  - Identical scores (zero diff, CI contains zero)
  - Clear winner (positive CI, significant p-value)
  - Seed determinism
  - Mismatched lengths (assertion error)
  - Empty p-values, all-significant, mixed significance
  - Adjusted p-value ordering

🫏 Generated with [Claude Code](https://claude.ai/code)