### PR TITLE
feat(cat5): break out isolates by entity_type

### DIFF
--- a/sme/categories/gap_detection.py
+++ b/sme/categories/gap_detection.py
@@ -79,6 +79,7 @@ class GapDetectionReport:
     betti_1_largest: int
     h1_max_persistence: float
     h1_skipped: bool = False
+    isolated_by_type: dict[str, int] = field(default_factory=dict)
     h1_skip_reason: str = ""
 
     # Candidate gaps across components (top-K by score, post-filter)
@@ -263,6 +264,11 @@ def score_gap_detection(
     components = sorted(components_raw, key=len, reverse=True)
 
     isolated = [c for c in components if len(c) == 1]
+    isolated_by_type: dict[str, int] = {}
+    for comp in isolated:
+        node_id = next(iter(comp))
+        etype = G.nodes[node_id].get("entity_type", "unknown")
+        isolated_by_type[etype] = isolated_by_type.get(etype, 0) + 1
     largest = components[0] if components else set()
 
     bridges = _structural_bridges(G)
@@ -334,6 +340,7 @@ def score_gap_detection(
         components=len(components),
         largest_component_size=len(largest),
         isolated_nodes=len(isolated),
+        isolated_by_type=isolated_by_type,
         bridges=bridges,
         betti_0_largest=betti_0,
         betti_1_largest=betti_1,
@@ -403,8 +410,15 @@ def format_report(report: GapDetectionReport) -> str:
         f"  Components:            {report.components:,}",
         f"  Largest component:     {report.largest_component_size:,}",
         f"  Isolated nodes:        {report.isolated_nodes:,}",
-        f"  Structural bridges:    {len(report.bridges):,}",
     ]
+    if report.isolated_by_type:
+        for etype, count in sorted(
+            report.isolated_by_type.items(), key=lambda kv: -kv[1]
+        ):
+            lines.append(f"      {etype}: {count}")
+    lines.append(
+        f"  Structural bridges:    {len(report.bridges):,}"
+    )
     if report.bridges and len(report.bridges) <= 10:
         for u, v in report.bridges[:10]:
             lines.append(f"    {u} — {v}")

--- a/tests/test_gap_detection.py
+++ b/tests/test_gap_detection.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import pytest
 
-from sme.categories.gap_detection import score_gap_detection
+from sme.categories.gap_detection import format_report, score_gap_detection
 
 ripser = pytest.importorskip  # alias for readability below
 
@@ -154,3 +154,21 @@ def test_empty_graph_is_all_zeros():
     assert report.isolated_nodes == 0
     assert report.bridges == []
     assert report.candidate_gaps == []
+
+
+# --- Isolated-by-type (#14) -------------------------------------------
+
+
+def test_isolated_by_type(gap_graph):
+    """Issue #14 — isolates broken out by entity_type."""
+    entities, edges, _ = gap_graph
+    report = score_gap_detection(entities, edges, run_homology=False)
+    assert report.isolated_by_type == {"tag": 1}
+
+
+def test_format_report_shows_isolate_types(gap_graph):
+    """Issue #14 — format_report includes type breakdown for isolates."""
+    entities, edges, _ = gap_graph
+    report = score_gap_detection(entities, edges, run_homology=False)
+    rendered = format_report(report)
+    assert "tag: 1" in rendered


### PR DESCRIPTION
## Summary

Closes #14.

- Adds `isolated_by_type: dict[str, int]` to `GapDetectionReport` — counts isolated nodes grouped by `entity_type`
- Computed during the existing component iteration, zero additional graph traversal
- `format_report()` renders the breakdown when isolates exist (e.g., `topic: 1`)

## Test plan

- [x] `test_isolated_by_type` — verifies the dict matches fixture ground truth
- [x] `test_format_report_shows_isolate_types` — verifies rendered output contains type labels
- [x] Existing Cat 5 tests pass unchanged

🫏 Generated with [Claude Code](https://claude.ai/code)