### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,204 @@
+# Contributing to SME
+
+Thanks for picking this up. This doc is the minimum you need to land
+a PR that doesn't surprise anyone. It's short on purpose — when
+something isn't covered here, ask in the issue thread rather than
+guess. The repo's constitutional principle is **lightweight and
+locally runnable** ([rationale](docs/industry_standards_integration.md#constitutional-principle));
+most other conventions flow from that.
+
+## Dev setup
+
+```bash
+git clone https://github.com/M0nkeyFl0wer/multipass-structural-memory-eval
+cd multipass-structural-memory-eval
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[topology]"
+pip install pytest pytest-cov ruff pyyaml
+```
+
+`pip install -e .` gives you the core package; the `[topology]` extra
+adds Ripser + python-louvain (needed for Cat 5 gap detection). Adapter-
+specific extras (`[ladybugdb]`, `[neo4j]`) only matter if you're
+touching that adapter's code path.
+
+## Before you push
+
+CI runs ruff and pytest across Python 3.10 / 3.11 / 3.12. Run them
+locally first:
+
+```bash
+ruff check .
+python -m pytest tests/ -q
+```
+
+Both have to pass. Ruff errors are the most common cause of CI red
+and they're trivial to fix locally.
+
+If you're iterating on one adapter or one category, scope the test
+run:
+
+```bash
+python -m pytest tests/test_adapter_contract.py -k "ladybugdb" -v
+python -m pytest tests/test_gap_detection.py -v
+```
+
+## PRs
+
+**One issue per PR.** Reference it in the description: `Closes #N`.
+Smaller PRs land faster — if you're touching three categories, that's
+three PRs.
+
+**Stage explicit paths, not `git add -A` or `git add .`** This project
+is multi-agent friendly (several contributors run concurrent local AI
+sessions); broad adds pick up sibling work and land it in the wrong
+commit.
+
+**No AI co-author trailers** in commits, PR descriptions, or code. Tools
+don't own what you build with them.
+
+## Standards-first
+
+Before adding a new measurement module, category, or adapter,
+check [`docs/industry_standards_integration.md`](docs/industry_standards_integration.md).
+The audit catalogues which layers already have battle-tested standards
+(SHACL, PROV-O, OpenLineage, MCP-Bench naming, HELM cost-per-correct,
+YCSB latency, TREC bounds, BH-FDR) and where SME deliberately rolls
+its own.
+
+Two rules of thumb:
+
+1. **Wrap scipy / numpy / networkx; don't reimplement them.** If
+   `scipy.stats.bootstrap` already gives you a paired bootstrap CI,
+   wrapping it is preferable to a hand-rolled implementation. The
+   constitutional principle (lightweight + locally runnable) tolerates
+   scipy; it does not tolerate LangChain. Reimplementations carry bugs
+   the libraries don't and diverge from published numbers over time.
+
+2. **Cite the methodology in the module docstring.** If you're implementing
+   HELM-style cost-per-correct, YCSB latency percentiles, TREC random/
+   oracle bounds, or BH-FDR correction, name the paper. Future readers
+   shouldn't have to grep the issue thread to find out what convention
+   you followed.
+
+When in doubt, propose the integration in an issue first so the
+constitutional cost-benefit gets explicit discussion.
+
+## Adapter PRs
+
+If your PR adds, removes, or modifies an `SMEAdapter` subclass:
+
+1. **Parametrize it into the contract testkit.** `tests/test_adapter_contract.py`
+   runs every registered adapter through 27 conformance tests. Add
+   yours to the parametrize list. Don't ship without — the testkit is
+   the abstraction that catches the regression class PR #30 was built
+   around.
+
+2. **Implement the required ABC methods.** `ingest_corpus()`, `query()`,
+   `get_graph_snapshot()`. The three optional methods (`get_flat_retrieval()`,
+   `get_ontology_source()`, `get_harness_manifest()`) have defaults —
+   override only when your system has something better than the
+   default.
+
+3. **Register in the CLI allowlist.** `sme/cli.py` has an
+   `_ADAPTER_REGISTRY` tuple of `_AdapterSpec` entries. Add yours with
+   an explicit `accepts: frozenset[str]` listing the kwargs your
+   constructor takes. Unknown kwargs are silently dropped — this is
+   the structural fix that prevents drop-list drift, but it means a
+   forgotten `accepts` entry silently makes your adapter ignore CLI
+   flags.
+
+## Corpus PRs
+
+New corpora live under `sme/corpora/<corpus-name>/`. A complete corpus
+ships with:
+
+- `README.md` — domain framing, source-discovery pass, design intent
+- `ontology.yaml` — entity types, relation types, alias pairs,
+  injected defects
+- `ontology.py` — executable form for ingestion-time validation
+- notes/ — the actual hand-authored content
+- `questions.yaml` — annotated questions with `min_hops_in_ground_truth_graph`
+- `ground_truth.yaml` — expected sources per question
+- `validate.py` — corpus self-check (uniqueness, link integrity, frontmatter)
+
+See `sme/corpora/good-dog-corpus/` for the current reference layout.
+Corpora are hand-authored, not LLM-synthesized — at the scale SME
+operates (≤100 notes per corpus), the verifiability gain outweighs
+the authoring cost.
+
+## Spec edits and new categories
+
+`docs/sme_spec_v8.md` is the source of truth for what each category
+measures. **Circulate changes before they land** — open an issue with
+the proposed spec text, link the PRs that motivated it, give other
+contributors a few days to push back. Spec changes that ship without
+review create the kind of methodology drift that makes cross-paper
+comparison impossible.
+
+Edits that add or rename sub-statistics (e.g. the Cat 9a.1/9a.2/9a.3
+decomposition under discussion in #3) need a deprecation note for the
+prior shape so existing readings stay interpretable.
+
+**Proposing a new category** (Cat 10+):
+
+1. File an issue with the methodology source (JEPSEN, MCP-Bench, etc.)
+   and a worked-example reading.
+2. Discussion thread converges on the metric shape before any code.
+3. Spec PR with the category text — separate from any implementation PR.
+4. Implementation PR adds the category module, CLI subcommand, tests,
+   and an entry in the README's category status table.
+
+## Code quality bars
+
+These apply across the codebase, not just to measurement modules:
+
+- **No `assert` for input validation.** Asserts get stripped under
+  `python -O`. Raise `ValueError` / `TypeError` instead. Asserts in
+  tests are fine.
+- **Deterministic outputs.** Tie-breaks in voting / sorting / ranking
+  must be explicit — `Counter.most_common()` and sort-by-single-key on
+  ties both produce non-reproducible output. Pin the rule.
+- **No non-deterministic test behaviour.** `time.sleep()` in timing
+  assertions, float equality, unseeded RNG, sort-by-dict-iteration
+  all share the same shape and all cause flake. Use `pytest.approx()`,
+  mock clocks, and seeded RNG.
+- **Cheap-by-default tests.** If a test takes >1s on a typical CI run
+  (`n_bootstrap=10000`, etc.), make it cheap (`n_bootstrap=200`) and
+  add a separate slow variant if the larger N is load-bearing for the
+  assertion.
+
+## Issues
+
+When you file an issue:
+
+- Title names the thing concretely (`Cat 4c — per-edge-type component
+  count is structurally noisy on small edge populations`), not vaguely
+  (`improve Cat 4`).
+- Include the methodology source if you're proposing a metric shape
+  (HELM, YCSB, TREC, JEPSEN, BH-FDR, etc.).
+- If you're filing against a specific reading, link the result JSON
+  or commit hash that produced it.
+
+## Reviewing PRs
+
+We're a small project. Reviews lead with what worked before flagging
+what didn't — substantive disagreement is welcome, nitpicks should be
+clearly labelled as such so authors can triage.
+
+Two patterns worth naming explicitly:
+
+- **Copilot-bot review comments are noisy by default.** Treat them as
+  a starting point, not a checklist. Some flags (asserts that disappear
+  under `-O`, non-deterministic tie-breaks, missing input validation)
+  are real and worth fixing; many (dead loggers, "use approx", float
+  equality in tests where the result is integer-valued) are noise.
+- **When you spot the same shape across three or more PRs**, that's
+  usually a signal to build an abstraction (testkit, pre-commit hook,
+  shared helper) rather than fixing the same thing per-PR.
+
+## License
+
+MIT. No CLA, no contributor agreement; opening a PR signals you're
+licensing the contribution under the same terms as the rest of the
+repo.

--- a/commits/2026-05-25.md
+++ b/commits/2026-05-25.md
@@ -1,0 +1,854 @@
+---
+type: commit-log
+created: 2026-05-25T00:00:00Z
+source: git-hook
+status: active
+---
+
+# Commit Log: 2026-05-25
+
+## The-Monkey-Flower-Experiment/main — e0a0063 [monkey-flower]
+
+- **time**: 2026-05-25T12:00:09-04:00
+- **device**: monkey-flower
+- **message**: mf-graph: narrative layer gets its own narrative.ldb
+- **files**: 5 changed ( 5 files changed, 48 insertions(+), 61 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+mf-graph/mf_graph/config.py
+mf-graph/scripts/backfill_chapter_1_metadata.py
+mf-graph/scripts/export_narrative.py
+mf-graph/scripts/load_extracted_chapter_1.py
+mf-graph/tests/fixture_corpus/extracted/chapter_1/HANDOFF.md
+```
+
+> build.py (structural rebuild) and load_extracted_chapter_1.py (narrative
+loader) used to share graph.ldb under different ID schemes — CHR-/SCN-/
+FAC- hashes vs slug/Scene_p*/FAC_*. The narrative loader's fresh-build
+pattern wiped build.py's nodes on every rerun; build.py duplicated every
+character on its next cron tick. The exporter worked around it by
+namespace-scoping all queries, but that left graph.ldb in an inconsistent
+state between the two pipelines.
+
+Per mf-graph/.claude/CLAUDE.md ("different ontologies = different
+databases"), split:
+
+- config: NARRATIVE_GRAPH_DB_PATH = .vault-idx/narrative.ldb
+- load_extracted_chapter_1.py, backfill, export_narrative: open
+  GraphWriter(db_path=NARRATIVE_GRAPH_DB_PATH) instead of the default
+- build.py / monkey-flower-rebuild.timer keep graph.ldb (structural)
+
+Verified by rebuilding narrative.ldb from scratch and re-exporting: the
+new dataset matches the committed one byte-for-byte (Cypher result order
+differs but content is identical). The exporter's namespace-scoping is
+now belt-and-suspenders. Also drops the "stop the API service first"
+pre-req from all three scripts — the API holds graph.ldb only.
+
+## phase1-postgres-hybrid/phase1-postgres-hybrid — ce6f93b [monkey-flower]
+
+- **time**: 2026-05-25T12:01:52-04:00
+- **device**: monkey-flower
+- **message**: fix(layer3): autocommit wrap in _check_identity (INTRANS backport)
+- **files**: 1 changed ( 1 file changed, 24 insertions(+), 10 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+atlas_graphbody/storage/postgres_writer.py
+```
+
+> Same fix as vault_rag commit cb4c09c — psycopg-pool's configure hook
+rejects a connection left in INTRANS state. A bare SELECT in default
+autocommit-off mode starts an implicit transaction. Wrapping the
+check in autocommit-on resolves it. Mock tests didn't catch it; real
+pool integration does.
+
+## The-Monkey-Flower-Experiment/main — 1e794b5 [monkey-flower]
+
+- **time**: 2026-05-25T12:24:52-04:00
+- **device**: monkey-flower
+- **message**: ch.1 extraction: drop 2 artifact PROMISES, reclassify romance as Beat
+- **files**: 7 changed ( 7 files changed, 91 insertions(+), 140 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+charvis/web/public/narrative/appearances.json
+charvis/web/public/narrative/characters.json
+charvis/web/public/narrative/narrative-edges.json
+charvis/web/public/narrative/summary.json
+mf-graph/tests/fixture_corpus/extracted/chapter_1/HANDOFF.md
+mf-graph/tests/fixture_corpus/extracted/chapter_1/second_pass.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_1/threads.jsonl
+```
+
+> The "Narrative" view had 3 empty character lanes — `unknown`,
+`campus_intranet`, `corin_tria_romantic_relationship` — because the
+loader's object-type heuristic typed all three as Characters.
+
+- second_pass.jsonl: dropped two PROMISES edges both flagged
+  "for entity-resolution" in their own notes — Alex's DM to an
+  unspecified recipient, and Tria's journalistic "we'll keep you
+  informed" to the campus audience. Neither has a single-person
+  object; re-extract if either turns out load-bearing.
+- threads.jsonl: renamed FORESHADOWS object "Corin-Tria romantic
+  relationship" → "Beat_CorinTriaRomance" so the loader's `Beat_`
+  prefix routes it through FORESHADOWS_EVENT instead of falling
+  through to Character.
+
+Loader now reports 347/347 edges, 0 skips, 21 real characters
+(was 348/349, 1 skip, 24 with 3 empty lanes). HANDOFF updated.
+
+## The-Monkey-Flower-Experiment/main — 80da655 [monkey-flower]
+
+- **time**: 2026-05-25T13:31:26-04:00
+- **device**: monkey-flower
+- **message**: archive: retire MASTER-TODO.md
+- **files**: 5 changed ( 5 files changed, 876 insertions(+), 878 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+.claude/CLAUDE.md
+MASTER-TODO.md
+archive/MASTER-TODO.md
+docs/SOCIAL_POST_MAP.md
+mf-graph/mf_graph/config.py
+```
+
+> MASTER-TODO.md has been outdated for a while — its scene roadmap was
+the work plan from Mar 2026 and the actual drafting has long since
+moved past what it tracks. Moved to archive/ and removed the three
+references (.claude/CLAUDE.md key-file table, docs/SOCIAL_POST_MAP.md
+sidebar pointer, config.py IMPORTANT_FILENAMES set).
+
+## The-Monkey-Flower-Experiment/main — fd43c2f [monkey-flower]
+
+- **time**: 2026-05-25T13:31:26-04:00
+- **device**: monkey-flower
+- **message**: ch.2 fixture: extract pages 24-40 from manuscript
+- **files**: 1 changed ( 1 file changed, 695 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+mf-graph/tests/fixture_corpus/chapter_2.md
+```
+
+> Same shape as chapter_1.md — the 695-line slice (pages 24-40, 17 pages,
+post-storm cleanup and faculty meeting through Randy's mushroom ride)
+sourced from chapters/Mandate-MF-Master.novel-wip.md as the input to
+the next round of 5 specialist extraction agents.
+
+The "Chapter 2+ uses older format" warning in .claude/CLAUDE.md was
+also stale — ch.2 is fully in surveillance-frame format already.
+
+## The-Monkey-Flower-Experiment/main — 4d1e130 [monkey-flower]
+
+- **time**: 2026-05-25T14:27:03-04:00
+- **device**: monkey-flower
+- **message**: mf-graph: generalize loader + backfill across chapters
+- **files**: 7 changed ( 7 files changed, 525 insertions(+), 491 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+mf-graph/mf_graph/indexer/json_exporter.py
+mf-graph/scripts/backfill_chapter_1_metadata.py
+mf-graph/scripts/backfill_metadata.py
+mf-graph/scripts/export_narrative.py
+mf-graph/scripts/load_extracted.py
+mf-graph/scripts/load_extracted_chapter_1.py
+mf-graph/tests/fixture_corpus/extracted/chapter_1/HANDOFF.md
+```
+
+> load_extracted.py (was load_extracted_chapter_1.py) now discovers every
+tests/fixture_corpus/extracted/chapter_*/ directory and loads them all
+into narrative.ldb in a single fresh-build pass. Each edge gets
+extractor_run_id = "<chapter>.<ts>" and provenance = "llm:<chapter>:<bucket>"
+so downstream review can trace what came from where.
+
+backfill_metadata.py (was backfill_chapter_1_metadata.py) replaces the
+hardcoded chapter=1 with PAGE_TO_CHAPTER ranges; extend the table when a
+new chapter's fixture lands. Scenes with a page outside the known
+ranges still get page set, just no chapter — flagged in the printout.
+
+export_narrative.py and the json_exporter docstring updated to point at
+the new names. HANDOFF re-run instructions and key-files table refreshed.
+
+## The-Monkey-Flower-Experiment/main — bf3d4e9 [monkey-flower]
+
+- **time**: 2026-05-25T14:27:17-04:00
+- **device**: monkey-flower
+- **message**: ch.2 extraction + regenerated charvis narrative dataset
+- **files**: 10 changed ( 10 files changed, 2475 insertions(+), 303 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+charvis/web/public/narrative/appearances.json
+charvis/web/public/narrative/characters.json
+charvis/web/public/narrative/factions.json
+charvis/web/public/narrative/narrative-edges.json
+charvis/web/public/narrative/summary.json
+mf-graph/tests/fixture_corpus/extracted/chapter_2/deceit_witness.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/faction.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/romance.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/structural.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/threads.jsonl
+```
+
+> 240 edges extracted from chapter 2 (pages 24-40) by 5 specialist agents
+in parallel — structural (139), faction (39), threads (53), romance (3),
+deceit_witness (6). Loaded into narrative.ldb alongside ch.1: 587/587
+edges total, 0 SKIPs.
+
+Threads-agent scene IDs were normalized post-extraction to match the
+structural agent's slugs (16 renames in threads.jsonl, 2 in
+deceit_witness.jsonl) so cross-bucket references resolve to the same
+Scene nodes.
+
+charvis narrative dataset reflects both chapters: 28 characters
+(+7 new in ch.2 — Cleo Morrison, Rueben Thunderbird, Luke Thunderbird,
+Don Weaver, Amy, Troy, Amir Patel), 240 narrative edges, 34 pages.
+
+Three new characters lack codex entries and show as grey lanes —
+Amy, Cleo Morrison, Rueben Thunderbird (the last one is likely the
+codex's "Rueben George" NAT-0003 under a different surname, flagged
+for author reconciliation). The faction agent also flagged Melanie's
+ch.1-student → ch.2-faculty reclassification (FAC-0744 in ch.2) and
+Teresa Okonkwo's ch.1-displaced → ch.2-student (STU-3310) shifts.
+
+## phase-f-chunk-decommission/phase-f-chunk-decommission — 9676256 [monkey-flower]
+
+- **time**: 2026-05-25T14:53:57-04:00
+- **device**: monkey-flower
+- **message**: phase-f: schema + DuckDB setup script (eo_chunks.duckdb, fts, vss)
+- **files**: 2 changed ( 2 files changed, 154 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+pyproject.toml
+scripts/storage-foundation/phase_f_setup.sh
+```
+
+> Creates data/eo_chunks.duckdb with the fts + vss extensions, the
+documents + chunks tables, and the HNSW index on chunks.embedding.
+Mirrors seabrick Phase F setup pattern. Adds duckdb>=1.1.0 to
+pyproject.toml.
+
+Operation Liberate The Ladybugs: lifts the chunk payload off Lady so
+the typed-edge graph can breathe. Schedule: scheduled after atlas
+Phase 1 acceptance (verified 2026-05-25).
+
+## phase-f-chunk-decommission/phase-f-chunk-decommission — 74ab438 [monkey-flower]
+
+- **time**: 2026-05-25T14:53:57-04:00
+- **device**: monkey-flower
+- **message**: phase-f: DuckDBChunkStore (add_chunk/bulk_add/search/vector_search/hybrid_search)
+- **files**: 1 changed ( 1 file changed, 525 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+election_oracle/storage/duckdb_chunk_store.py
+```
+
+> 525-line chunk store with surface matching existing sqlite-vec
+sidecars (relation_embeddings.sqlite, extraction_queue.sqlite) so
+callers swap cleanly. add_document, add_chunk (idempotent INSERT OR
+IGNORE), bulk_add_chunks, search (FTS), vector_search (HNSW + linear
+fallback), hybrid_search (RRF fusion), rebuild_fts.
+
+## phase-f-chunk-decommission/phase-f-chunk-decommission — be2ec04 [monkey-flower]
+
+- **time**: 2026-05-25T14:53:57-04:00
+- **device**: monkey-flower
+- **message**: phase-f: wire EO_LADYBUG_CHUNK_DUAL_WRITE in 5 ingest paths (default=1, dual-write preserved)
+- **files**: 1 changed ( 1 file changed, 217 insertions(+), 43 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+election_oracle/api/server.py
+```
+
+> Six edits to server.py: a globals/helper block + five ingest entry
+points (_ingest_staged_doc, add_intel, upload_csv_intel,
+_ingest_single_url, research_ingest). Each entry point now:
+  - calls get_chunk_store().add_document(...) + add_chunk(...) UNCONDITIONALLY
+  - gates the LadybugDB Chunk write behind _eo_ladybug_chunk_dual_write_enabled()
+  - logs per-side counts: ladybug=Nd/Nc duckdb=Md/Mc
+
+Default EO_LADYBUG_CHUNK_DUAL_WRITE=1 preserves current behaviour.
+DuckDB writes are always-on. Flip to 0 documented in runbook (commit 5)
+— held back pending real-corpus parity verification.
+
+## phase-f-chunk-decommission/phase-f-chunk-decommission — 729a664 [monkey-flower]
+
+- **time**: 2026-05-25T14:53:57-04:00
+- **device**: monkey-flower
+- **message**: phase-f: tests — flag parsing, DuckDBChunkStore, ingest wiring, ATTACH
+- **files**: 1 changed ( 1 file changed, 531 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+tests/test_eo_phase_f.py
+```
+
+> 44 passed, 1 skipped. Covers flag truthy/falsy parsing, DuckDBChunkStore
+public surface (add_chunk/add_document/bulk/search/stats), ingest
+gate behaviour (flag on/off counts), and Lady ATTACH snippet format.
+
+## phase-f-chunk-decommission/phase-f-chunk-decommission — 4735980 [monkey-flower]
+
+- **time**: 2026-05-25T14:53:58-04:00
+- **device**: monkey-flower
+- **message**: phase-f: runbook (EO_PHASE_F_CHUNK_DECOMMISSION.md) — default flip pending parity
+- **files**: 1 changed ( 1 file changed, 253 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+docs/EO_PHASE_F_CHUNK_DECOMMISSION.md
+```
+
+> Documents the Phase F architecture (Lady + DuckDB native pair), the
+parity verification procedure (dual-write for N days, count tables,
+compare chunk_id sets), and the one-line default flip:
+  os.environ.get('EO_LADYBUG_CHUNK_DUAL_WRITE', '1' → '0').lower().strip()
+
+Per the campaign house rule, the flip itself is a SEPARATE commit
+after parity verifies — making 'git revert <hash>' the universal
+rollback.
+
+## The-Monkey-Flower-Experiment/main — d46659f [monkey-flower]
+
+- **time**: 2026-05-25T16:21:26-04:00
+- **device**: monkey-flower
+- **message**: ch.1-2 author reconciliation: canonical names + Melanie staff_assoc rep
+- **files**: 14 changed ( 14 files changed, 253 insertions(+), 267 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+characters/amy/entry.md
+characters/cleo-morrison/entry.md
+characters/troy/entry.md
+charvis/web/public/narrative/appearances.json
+charvis/web/public/narrative/characters.json
+charvis/web/public/narrative/factions.json
+charvis/web/public/narrative/narrative-edges.json
+charvis/web/public/narrative/summary.json
+mf-graph/tests/fixture_corpus/extracted/chapter_1/affect.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_1/faction.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_1/second_pass.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_1/structural.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/faction.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/structural.jsonl
+```
+
+> Author calls on the flags surfaced by the ch.2 extraction agents:
+
+- Canonical names. Renamed across ch.1+ch.2 JSONL so the loader merges
+  to a single Character node per person:
+    Teresa T → Teresa Okonkwo (Teresa Okonkwo is canonical; ch.1 only had
+      the surveillance shorthand)
+    Melanie → Melanie Lariviere (she is faculty, not a student; ch.1's
+      "Melanie" social-handle alias resolves to the same person)
+    Karen → Karen Stevens
+    Rueben Thunderbird → Rueben George (government name canonical in
+      characters.json; "Thunderbird" is the spiritual name and stays an
+      alias in the codex)
+
+- Melanie reclassification. Dropped ch.1's MEMBER_OF FAC_STUDENTS
+  (extractor mistake) and added MEMBER_OF FAC_STAFF_ASSOC in ch.2 —
+  she's faculty by employment AND the Staff Association representative.
+
+- Teresa faction. Converted ch.1's MEMBER_OF FAC_REFUGEES to
+  ALIGNED_WITH (degree 0.85). She herself is a student (STU-3310 in
+  ch.2); her family was sheltering in the gym.
+
+- 26 Character nodes after reconciliation (was 28); 587/587 edges
+  loaded across both chapters, 0 SKIPs.
+
+Stub codex entries created for the three remaining unflagged new
+characters: Cleo Morrison (FAC-1108, faculty, Morrison family),
+Amy (juvenile witness on p37), Troy (Teresa's pod-mate on p27).
+Each entry marks itself STUB and lists what's known + what's open.
+
+Note on the Amanda STU-ID drift (codex 5501 vs ch.2 manuscript 5507):
+left as-is per author "good catch" acknowledgement — not yet resolved.
+
+## The-Monkey-Flower-Experiment/main — edcee04 [monkey-flower]
+
+- **time**: 2026-05-25T16:30:23-04:00
+- **device**: monkey-flower
+- **message**: Amanda Chen: canonize STU-5501 (was STU-5507 in manuscript)
+- **files**: 6 changed ( 6 files changed, 55 insertions(+), 55 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+chapters/Mandate-MF-Master.novel-wip.md
+charvis/web/public/narrative/appearances.json
+charvis/web/public/narrative/narrative-edges.json
+mf-graph/tests/fixture_corpus/chapter_2.md
+mf-graph/tests/fixture_corpus/extracted/chapter_2/faction.jsonl
+mf-graph/tests/fixture_corpus/extracted/chapter_2/threads.jsonl
+```
+
+> The ch.2 manuscript and the codex disagreed on Amanda's student ID —
+codex says STU-5501, manuscript said STU-5507. Author call: 01 wins.
+
+Renamed 18 occurrences across:
+- chapters/Mandate-MF-Master.novel-wip.md (12)
+- mf-graph/tests/fixture_corpus/chapter_2.md (2)
+- mf-graph/tests/fixture_corpus/extracted/chapter_2/faction.jsonl (3)
+- mf-graph/tests/fixture_corpus/extracted/chapter_2/threads.jsonl (1)
+
+Narrative dataset regenerated; no edge-count change.
+
+## The-Monkey-Flower-Experiment/main — fa5316f [monkey-flower]
+
+- **time**: 2026-05-25T16:56:05-04:00
+- **device**: monkey-flower
+- **message**: ch.2 audit: three-way fidelity comparison (read-only report)
+- **files**: 1 changed ( 1 file changed, 233 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+chapters/CHAPTER_2_FIDELITY_AUDIT.md
+```
+
+> Compares original prose (mandate-monkey-flower.txt:78-173) against the
+current canonical manuscript and the .scene-kanban/Master.work.md
+draft. 34 original beats: ~24 preserved, ~5 partial, ~5 dropped.
+
+Findings the author flagged for reintroduction (via separate PRs):
+- Page 23 "Walking Dead" dawn opener (biggest gap)
+- Kamea's intermediate stop at Amanda's pod (wine, knocked photos)
+- AR vital-signs scan between Kamea and Amanda
+- The "find new ways to skate it" backside-lipslide line
+- Melanie's hand-knit salmon sweater
+- Kamea reappearing outside the gym (currently heart-gif reads as
+  Randy-alone; in original Kamea engineers it)
+- Troy's role + dialogue on page 27 (currently a name-in-comment only)
+
+FIREKEEPER name question settled by author: Randy stays Randy Hoskins
+in ch.2; the FIREKEEPER name is *given* to him later by Rueben in ch.4
+ceremony. Do not port the FIREKEEPER labels from the draft.
+
+No manuscript edits in this commit.
+
+## mari-daemon-flags/agent/mari-daemon-flags — 9ad929b [monkey-flower]
+
+- **time**: 2026-05-25T16:58:15-04:00
+- **device**: monkey-flower
+- **message**: feat(daemon): --pg-dsn and --extra-vault flags for per-project tenants
+- **files**: 2 changed ( 2 files changed, 228 insertions(+), 9 deletions(-))
+- **author**: Ben West
+
+```
+tests/test_daemon_cli.py
+vault_rag/indexer/daemon.py
+```
+
+> Both flags exist to stop cross-vault content leaks when the daemon binary
+is shared across multiple per-project tenants (vault-rag-daemon,
+mari-kg-daemon, atlas-kg-daemon, etc.).
+
+--pg-dsn STR (default: None)
+  When omitted, PostgresWriter uses its built-in default DSN (vault_rag).
+  Per-project daemons should pass an explicit DSN scoped to their own
+  pg DB. Previously every daemon process silently defaulted to vault_rag,
+  which pg_hba L1 then rejected silently.
+
+--extra-vault PATH (repeatable)
+  Replaces the previous unconditional Path.home()/'obsidian-vault'
+  auto-watch. m0nk's vault-rag-daemon.service should add
+  --extra-vault ~/obsidian-vault to preserve current behaviour;
+  per-project units leave it unset. mari-kg-daemon was unwittingly
+  indexing m0nk's obsidian vault into Mari's .vault-idx graph for ~9
+  days under the old code path.
+
+Tests in tests/test_daemon_cli.py verify both flags via click.testing
+(observer + embedder + queue + sleep stubbed). The pre-existing
+tests/test_daemon.py file references an outdated VaultEventHandler
+signature and is broken on this branch; left untouched here.
+
+Context: kg-common/docs/handoffs/2026-05-25/HANDOFF_mari_kg_proper_setup_and_decontamination.md
+Branch base: bake-off/vela @ c42998d (deployed daemon code; local-only)
+
+## The-Monkey-Flower-Experiment/main — f275500 [monkey-flower]
+
+- **time**: 2026-05-25T17:01:05-04:00
+- **device**: monkey-flower
+- **message**: ch.2 audit: correction — Walking Dead is preserved as chapter opener
+- **files**: 1 changed ( 1 file changed, 15 insertions(+), 12 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+chapters/CHAPTER_2_FIDELITY_AUDIT.md
+```
+
+> Initial audit reading was wrong. The CAM-20 LIBRARY PLAZA 06:14:07
+walking-dead surveillance content IS in canonical, at lines 1032-1050
+as a chapter-opener frame before the morning social-post sidebar and
+Page 24. All five elements of the original prose paragraph (sun
+coming out, people stumbling, crying/coughing, hum gone, destroyed
+city visible) are present.
+
+What the draft has that canonical doesn't is just the `## Page 23`
+header promoting this content to a discrete spread — a layout call,
+not a fidelity gap.
+
+Six confirmed reintroduction PRs identified, ordered smallest first
+(Melanie's salmon sweater) to biggest (Amanda's pod intermediate
+stop with wine + knocked photos).
+
+## hybrid-OG-vault-rag/bake-off/vela — 0bdfc72 [monkey-flower]
+
+- **time**: 2026-05-25T17:13:27-04:00
+- **device**: monkey-flower
+- **message**: fix(extraction): inject grade_locality rules from schema into prompts
+- **files**: 1 changed ( 1 file changed, 108 insertions(+), 42 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+scripts/claude_enrich.py
+```
+
+> Prompt now embeds the schema's grade_locality block as hard endpoint-type
+constraints. The same YAML that EPC monitors against is loaded at
+module-load and appended to TECHNICAL/GENERAL/SESSION prompts. Tells the
+LLM to OMIT rather than misclassify when no allowed source→target pair
+applies.
+
+Notable extra guidance:
+- SUPERSEDES is same-type only (decision↔decision, pattern↔pattern)
+- DECIDED_IN target is a Note node — entity-to-entity extraction has no
+  valid target, so the prompt says don't emit it (the system writes
+  DECIDED_IN at note ingest time, not via this pipeline)
+- FAILED_BECAUSE source must be anti_pattern
+- RELATED source types not in the schema's table get dropped
+
+Validated on a 15-note batch: EPC violations net -60 across the run
+(DECIDED_IN +1, FAILED_BECAUSE +0, RELATED -62, SUPERSEDES +1). The
+extractor produced 0 DECIDED_IN edges (was the dominant violator) and
+RELATED's share of typed edges dropped from ~54% to 42%.
+
+NOVEL_PROMPT is intentionally untouched — it uses a different edge
+vocabulary (APPEARS_IN, etc.) that grade_locality doesn't cover.
+
+Schema is the single source of truth — any change to ontology/schema.md
+grade_locality block flows into the prompt on next module load.
+
+## hybrid-OG-vault-rag/bake-off/vela — 16428a3 [monkey-flower]
+
+- **time**: 2026-05-25T17:57:42-04:00
+- **device**: monkey-flower
+- **message**: fix(identity): widen canonicalize_name to strip punctuation + articles
+- **files**: 2 changed ( 2 files changed, 70 insertions(+), 8 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+tests/test_slug_canonicalization.py
+vault_rag/schema/identity.py
+```
+
+> Pre-2026-05-25 canonicalize_name only collapsed [-_\s]+, so variants
+like 'Graph DB' / 'graph.db', 'The Monkey Flower' / 'monkey-flower',
+'vault_rag/api' / 'vault-rag API' produced distinct entity rows. The
+integrity_monitor DUP check surfaced 118 such collision groups on the
+live graph; the existing migrate_entity_id_collisions.py finds 151
+when run with the stricter form.
+
+New normalization:
+- lowercase + strip
+- drop leading articles (the/a/an)
+- collapse every non-alphanumeric run to one space
+- collapse whitespace, trim
+
+'Graph DB' / 'graph.db' / 'graph-db' all → 'graph db'.
+'The Monkey Flower' / 'monkey-flower' all → 'monkey flower'.
+'vault_rag/api' / 'vault-rag API' / 'vault_rag/api/' all → 'vault rag api'.
+
+legacy_canonicalize_name kept for the merge script — existing rows
+were slugged under the old form, so finding their old IDs from a name
+still needs the previous normalization.
+
+This is the prevention half — new writes can't create new collisions.
+The heal of the existing 151 groups is the standalone migration:
+  systemctl --user stop knowledge-graph-api vault-rag-builder.timer \
+    vault-rag-daemon
+  .venv/bin/python scripts/storage-foundation/migrate_entity_id_collisions.py
+  systemctl --user start vault-rag-daemon vault-rag-builder.timer \
+    knowledge-graph-api
+
+Tests: 5/5 passing, adds two new regression tests covering the new
+collapse cases and the empty/junk-input safety.
+
+## hybrid-OG-vault-rag/bake-off/vela — f52b298 [monkey-flower]
+
+- **time**: 2026-05-25T19:01:55-04:00
+- **device**: monkey-flower
+- **message**: feat(enrich): integrity gate + ollama model parameterization
+- **files**: 1 changed ( 1 file changed, 112 insertions(+), 4 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+scripts/auto_enrich.sh
+```
+
+> Two related operational improvements to scripts/auto_enrich.sh.
+
+## Integrity gate (new this commit)
+
+After eval, runs scripts/integrity_monitor.py --json and compares
+EPC/DUP/EV/CC violation counts against a snapshot taken at the top
+of the run. If any monitor's violation count grew by > 5% AND > 50
+absolute, exits non-zero so the OnFailure= drop-in
+(50-on-failure.conf) fires the alert handler.
+
+Detection only at this layer — healing stays in the weekly
+vault-rag-maintenance.timer window (task: --fix mode on
+integrity_monitor). Each burst now leaves the graph at least no
+worse than it started — bad-prompt or bad-canonicalization changes
+can't silently amplify violations at scale.
+
+Monitor exit code handling: 0 (ok) and 1 (anomaly) both produce
+usable JSON; only 2+ (schema_gap) disables the gate for that run.
+Pre and post snapshots written to /tmp/kg-integrity-{pre,post}-$$.json
+and cleaned up at the end.
+
+Validated against synthetic regressions: +10% EPC trips the gate
+with exit 2 (translates to exit 1 for systemd), no-change passes.
+
+## Ollama model parameterization (was already in working tree)
+
+Previously hardcoded qwen3.5:35b-a3b. Switched to OLLAMA_MODEL env
+var defaulting to qwen3:14b (9.3 GB). The 35b model at 23.9 GB was
+evicting vault-rag's embedding model on seshat's GPU; ~50% of
+generations timed out at the 5-min HTTP budget per 2026-05-24 smoke.
+The 14b model coexists with the embedding model in the remaining
+~12 GB of VRAM. Probe + label propagation now use ${OLLAMA_MODEL}
+consistently.
+
+## hybrid-OG-vault-rag/bake-off/vela — af35bd8 [monkey-flower]
+
+- **time**: 2026-05-25T19:28:25-04:00
+- **device**: monkey-flower
+- **message**: feat(integrity): --fix mode for healing EPC/CC anomalies + weekly schedule
+- **files**: 2 changed ( 2 files changed, 168 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+scripts/integrity_monitor.py
+scripts/weekly_maintenance.sh
+```
+
+> Adds a --fix subcommand to scripts/integrity_monitor.py so the same
+script that detects anomalies can also heal them. Default is dry-run;
+--apply enqueues Cypher to the graph_queue.
+
+## --fix cc
+
+Drops ENTITY_TO_ENTITY edges with confidence = 0.0. These are
+null-coalesce errors from the extractor (LLM didn't supply a
+confidence; writer defaulted to 0.0). Currently 2,266 such edges.
+
+## --fix epc
+
+Reroutes non-RELATED grade_locality violators to RELATED, preserving
+the original edge_type in r.original_edge_type. One UPDATE per
+(edge_type, src_type, tgt_type) combo — batched so 10,656 violating
+edges land in ~301 enqueue calls.
+
+Adds an idempotent ALTER TABLE for the original_edge_type column at
+the start; the builder swallows duplicate-column errors per its
+existing idempotent-DDL handler.
+
+RELATED-source violations (88 combos / 3,397 edges where the source
+type isn't in RELATED's allowed list in the schema) are NOT touched:
+rerouting RELATED → RELATED is a no-op, and deleting throws away
+legitimate LLM claims. They're a schema gap requiring either a
+RELATED rule widening or a per-edge `epc_excluded` flag — out of
+scope for the heal pass. Surfaced in the --fix epc report so the
+operator can see what was skipped.
+
+## --fix dup
+
+Prints the recipe for scripts/storage-foundation/migrate_entity_id_collisions.py
+rather than auto-running it. DUP heal needs API + builder + daemon
+stopped for single-writer access — too operationally heavy to chain
+into the routine --fix flow.
+
+## --fix all
+
+Runs cc + epc + dup (dup just prints). Convenience for the weekly
+maintenance window.
+
+## Weekly schedule
+
+scripts/weekly_maintenance.sh gains Phase 6 (run --fix cc + --fix epc
+with --apply, drain via builder) and Phase 7 (re-snapshot integrity to
+confirm the heal landed). Fires Sundays 04:00 via
+vault-rag-maintenance.timer.
+
+DUP healing stays manual because of the downtime requirement; the
+auto_enrich.sh gate catches DUP regressions per-burst so a one-shot
+sweep should be rare. Just ran the standalone migration tonight:
+0 collision groups remaining (was 118 before canonicalize_name
+widening surfaced 33 more for 151 total).
+
+## hybrid-OG-vault-rag/bake-off/vela — c7241d0 [monkey-flower]
+
+- **time**: 2026-05-25T21:28:37-04:00
+- **device**: monkey-flower
+- **message**: fix(integrity): disable --fix epc apply path (LadybugDB SET corrupts data)
+- **files**: 2 changed ( 2 files changed, 19 insertions(+), 4 deletions(-))
+- **author**: M0nkeyFl0wer
+
+```
+scripts/integrity_monitor.py
+scripts/weekly_maintenance.sh
+```
+
+> The multi-property SET pattern used by --fix epc apply silently
+corrupts data on LadybugDB:
+
+  MATCH (a)-[r:ENTITY_TO_ENTITY]->(b)
+  WHERE ... AND r.edge_type = $et
+  SET r.original_edge_type = $et, r.edge_type = 'RELATED'
+
+r.original_edge_type gets set correctly. But r.edge_type does NOT
+become 'RELATED' — each edge gets assigned what looks like an
+arbitrary value from across the edge_type vocabulary
+(CONTRADICTS, DERIVES_FROM, PART_OF, IMPLEMENTS, ...). Distribution
+suggests the SET value is being picked from a different row in the
+matched set rather than the literal.
+
+Got bit running --fix epc --apply on 10,656 edges across 301 batches:
+9,849 got original_edge_type set; only 1,388 (~14%) got the intended
+edge_type='RELATED'. The other 8,461 had their edge_type rotated to
+~12 different values, corrupting their semantic claim (a SUPERSEDES
+edge between tool→pattern became SUPPORTS or CONTRADICTS — false
+claims the LLM never made).
+
+Restored from the 19:17 graph-20260525T231641Z.tar.zst backup and
+re-ran the dedup migration. Current state: DUP=0, EV=100%, CC=ok,
+EPC=14,053 violations (pre-heal baseline). The EPC heal stays
+disabled until rewritten as two single-field SETs via parameters
+(never inline literals).
+
+Changes:
+- scripts/integrity_monitor.py: --fix epc --apply now short-circuits
+  with a warning instead of enqueueing. Dry-run output preserved.
+  Unreachable code kept below the early-return for the eventual
+  rewrite.
+- scripts/weekly_maintenance.sh: comment out EPC heal in Phase 6.
+  CC heal (simple DELETE on confidence=0 edges) and DUP heal
+  (delegates to safe migrate_entity_id_collisions.py) still
+  scheduled.
+
+Saved feedback memory: feedback-ladybug-multi-set.
+
+## mari-daemon-flags/agent/mari-daemon-flags — 40284f5 [monkey-flower]
+
+- **time**: 2026-05-25T16:58:15-04:00
+- **device**: monkey-flower
+- **message**: feat(daemon): --pg-dsn and --extra-vault flags for per-project tenants
+- **files**: 2 changed ( 2 files changed, 228 insertions(+), 9 deletions(-))
+- **author**: Ben West
+
+```
+tests/test_daemon_cli.py
+vault_rag/indexer/daemon.py
+```
+
+> Both flags exist to stop cross-vault content leaks when the daemon binary
+is shared across multiple per-project tenants (vault-rag-daemon,
+mari-kg-daemon, atlas-kg-daemon, etc.).
+
+--pg-dsn STR (default: None)
+  When omitted, PostgresWriter uses its built-in default DSN (vault_rag).
+  Per-project daemons should pass an explicit DSN scoped to their own
+  pg DB. Previously every daemon process silently defaulted to vault_rag,
+  which pg_hba L1 then rejected silently.
+
+--extra-vault PATH (repeatable)
+  Replaces the previous unconditional Path.home()/'obsidian-vault'
+  auto-watch. m0nk's vault-rag-daemon.service should add
+  --extra-vault ~/obsidian-vault to preserve current behaviour;
+  per-project units leave it unset. mari-kg-daemon was unwittingly
+  indexing m0nk's obsidian vault into Mari's .vault-idx graph for ~9
+  days under the old code path.
+
+Tests in tests/test_daemon_cli.py verify both flags via click.testing
+(observer + embedder + queue + sleep stubbed). The pre-existing
+tests/test_daemon.py file references an outdated VaultEventHandler
+signature and is broken on this branch; left untouched here.
+
+Context: kg-common/docs/handoffs/2026-05-25/HANDOFF_mari_kg_proper_setup_and_decontamination.md
+Branch base: bake-off/vela @ c42998d (deployed daemon code; local-only)
+
+## maris-little-helper/main — d28adcb [monkey-flower]
+
+- **time**: 2026-05-25T21:40:02-04:00
+- **device**: monkey-flower
+- **message**: snapshot prior to kg-common reconciliation
+- **files**: 20 changed ( 165 files changed, 17263 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+.github/workflows/ci.yml
+.gitignore
+CHANGELOG.md
+PLAN_TEMPORAL.md
+README.md
+data/SCHEMA.md
+data/archetypes.yaml
+docs/PIPELINE_FLOWS.md
+docs/issue-drafts/2026-05-05-per-type-schema/proposal.md
+docs/mari-knowledge-graph-mcp-stack.md
+docs/opencode-wrapper/00-CONSTITUTION.md
+docs/opencode-wrapper/01-ASSESSMENT.md
+docs/opencode-wrapper/02-PLAN.md
+docs/opencode-wrapper/03-TODO.md
+docs/opencode-wrapper/04-BEGIN.md
+docs/opencode-wrapper/05-FULL-BUILD-PLAN.md
+docs/opencode-wrapper/06-MVP-DECISIONS.md
+docs/opencode-wrapper/07-PHASE-IMPLEMENTATION-CHECKLIST.md
+docs/opencode-wrapper/08-SERVING-ASSESSMENT.md
+docs/opencode-wrapper/RECIPIENT-README.md
+```
+
+> 165 files captured as-is — the entire working tree was untracked
+before this commit. Includes:
+
+  - kg_common/agent/  (35M, real opencode-integration substrate;
+    19 .py files + static UI + dog photos)
+  - kg_common/media/  (144K, audio/image/video/document processors)
+  - mari-knowledge-graph-template/  (per-recipient profile)
+  - scripts/  (install-windows.ps1, MCP proxies, pi-backup, etc.)
+  - instructions/mari-opencode-rules.md
+
+Captured because the directory diverged from upstream kg-common
+(which removed agent/ and media/ as 'ghost shells' on 2026-05-19).
+Next step is to decide what gets re-promoted to real kg-common
+vs. what stays a per-recipient profile.
+
+## multipass-sme-main/contributing-doc — 4cbdfd3 [monkey-flower]
+
+- **time**: 2026-05-25T21:50:28-04:00
+- **device**: monkey-flower
+- **message**: docs: add CONTRIBUTING.md
+- **files**: 1 changed ( 1 file changed, 204 insertions(+))
+- **author**: M0nkeyFl0wer
+
+```
+CONTRIBUTING.md
+```
+
+> Single-pass contributor doc covering dev setup, pre-push CI
+expectations, PR conventions, the adapter contract testkit
+parametrization invariant, corpus PR shape, spec-edit circulation,
+the new-category proposal path, and the code-quality bars (no
+asserts for validation, deterministic outputs, no non-deterministic
+tests, cheap-by-default).
+
+Anchors the standards-first principle to docs/industry_standards_integration.md
+so new measurement modules get the audit as required reading rather
+than discovering it after a PR is written.
+


### PR DESCRIPTION
Single-pass contributor doc. Covers:

- **Dev setup** + scoped test runs (\`pytest -k\` on one adapter or one category)
- **PR conventions** — one issue per PR, explicit \`git add\` paths (multi-agent friendly), no AI co-author trailers
- **Standards-first** — anchors [\`docs/industry_standards_integration.md\`](docs/industry_standards_integration.md) as required reading before adding measurement modules. \"Wrap scipy; don't reimplement it\" rule with the bootstrap/BH-FDR case as the motivating example. Companion to #41.
- **Adapter PRs** — contract testkit parametrization invariant, ABC contract, registry \`accepts\` allowlist (so a forgotten \`accepts\` entry doesn't silently make a new adapter ignore CLI flags)
- **Corpus PRs** — the \`sme/corpora/<name>/\` shape, references \`good-dog-corpus\` as the reference layout, notes hand-authored-not-LLM-synthesized
- **Spec edits + new categories** — circulate-before-land convention; four-step process for proposing Cat 10+
- **Code quality bars** as general principles, not stats-only — no \`assert\` for validation, deterministic outputs, no non-deterministic test behaviour (time.sleep / float equality / unseeded RNG / sort-by-dict-iteration share the same shape)
- **Issues + reviewing** — naming Copilot-is-noisy and same-shape-three-times-equals-abstraction as the two live patterns
- **License** — MIT, no CLA

Self-merge if it reads right, or comment first. Doesn't need spec-circulation treatment since it's a process doc not a spec doc, but it does codify the spec-circulation rule for future contributors.