### PR TITLE
docs: founder-bound why/how gists + graph-benchmark 0.17.1 re-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ docs/related_work/wip/
 
 # Internal cross-repo commit journal — never publish (see 54f54ac)
 commits/
+docs/gists/.attic/

--- a/docs/gists/origin-how-multipass-began.md
+++ b/docs/gists/origin-how-multipass-began.md
@@ -1,0 +1,95 @@
+# How a one-page spec turned into a diagnostic toolkit
+
+This project started as a comment on someone else's issue, and a request I
+overshot by about an order of magnitude. Here's the actual story, because the
+way it began explains what it's for.
+
+## The palace
+
+I'd been reading through the [agentic-memory
+survey](https://github.com/lhl/agentic-memory) and got stuck on one system:
+[MemPalace](https://github.com/MemPalace/mempalace). Most memory systems are a
+vector store with a query box bolted on. MemPalace used a spatial metaphor
+instead — **wings** for domains, **halls** for edge types, **rooms** for topics,
+**tunnels** for the cross-domain connections between wings. An ontology expressed
+as *architecture* rather than declared in a schema file.
+
+That framing stuck with me, because it implied something most memory systems
+hide: a memory has a *shape*. You can't tell from `mempalace search` that your
+security wing has dense tunnels to devops but none to legal. You can't see the
+isolated wing with no tunnels to anything — a knowledge silo hiding in plain
+sight. Those are structural facts. They're already true in the palace; they're
+just invisible until you render the graph.
+
+So I [opened an issue](https://github.com/MemPalace/mempalace/issues/101) with
+three things: a 3D palace visualizer that made the structure walkable, a sketch
+of an eval framework that would test what the architecture uniquely enables, and
+a contradiction-detection pattern. The visualizer was the part I was excited
+about — I'd already built it on `3d-force-graph`, isolated wings glowing red,
+tunnels rendered as particle flow.
+
+## The reply that reframed it
+
+The maintainer — [@milla-jovovich](https://github.com/milla-jovovich), the Leeloo
+to this whole thing — took it through the CLI and replied to each piece. The
+visualizer she liked but parked: a visualization is only useful once the thing
+being visualized has settled shape, and the retrieval stack was still moving.
+
+Then she pointed at the part I'd treated as a footnote and called it the most
+important thing in the issue. Her reasoning is the reason this repo exists, so
+I'll quote the shape of it: a calibrated benchmark grid (@gizmax's work in their
+#39) had shown that, **under standard LongMemEval-style QA benchmarks**, the
+palace's room structure was a statistical no-op — one configuration even
+*regressed* ~13.6 points. But those benchmarks only measure single-question
+retrieve-and-answer. They can't score what the palace is actually *for*:
+multi-hop reasoning, cross-session connection, contradiction detection, tracking
+an entity as it changes over months. If the architecture has a real edge, it's on
+those axes — and standard QA benchmarks are the wrong lens to find it.
+
+Her ask was small and specific: **would I write the spec? Not the code — just the
+spec. A one-page write-up of what to test, why, and how you'd know it worked.**
+
+## Getting carried away
+
+I did not write a one-page spec.
+
+What happened instead is that I already had pieces lying around — the visualizer,
+some structural-analysis scripts I'd been using to poke at my own knowledge
+graph's health, a half-formed sense that "is this graph any good?" was a question
+nobody's retrieval benchmark answered. The spec request gave all of it a center
+of gravity. Each question on her one-pager turned into a test, each test wanted a
+metric, each metric wanted a corpus to run against and a baseline to compare to.
+I kept iterating the tools I'd built to make sense of graph health and
+retrieval-effectiveness in a RAG system, and they kept compounding.
+
+By the time I came back to the thread, what I had to report was: *"I realized I
+delivered a lot more than the one-page spec you asked for."* It had become a
+nine-category diagnostic framework — The Lookup (factual retrieval), The Stairway
+(multi-hop by depth), The Missing Room (structural gaps via topology), The
+Threshold (ingestion integrity), The Blueprint (ontology coherence), The Abacus
+(token efficiency), and eventually The Handshake (whether the model actually
+reaches the memory in production) — built and run across several corpora, against
+MemPalace and other graphs alike.
+
+The name *Multipass* is a double reference: multi-hop path traversal through the
+graph, and a Fifth Element callback, because the palace metaphor deserved one.
+(It's also literally what the framework does — multiple passes over every system
+under test, across corpus shapes and retrieval conditions, so behaviour that
+hides on any single pass shows up when the readings sit side by side.)
+
+## What it became
+
+The thing I didn't expect is that other people started running it on memory I'd
+never seen. One contributor pointed it at a 165K-drawer production palace and got
+back a structural snapshot nobody had had before — including a finding that one
+edge type held 73% of the graph, the kind of legible reading the framework was
+supposed to make possible. He also found a bug, which I fixed, which is how you
+know the tool is real.
+
+So that's the lineage: a metaphor that made me want to *see* a memory's shape, a
+maintainer who redirected me from the pretty part to the useful part, and a
+one-page spec I couldn't stop expanding. The founding observation hasn't changed,
+and it's the same one I keep coming back to — **standard benchmarks ask whether
+you can find a memory; they can't tell you whether the memory is structurally
+sound.** That gap is the whole project. (The longer-form version of that argument
+is in [the companion note](./why-benchmarks-cant-see-the-bug.md).)

--- a/docs/gists/why-and-how.md
+++ b/docs/gists/why-and-how.md
@@ -1,0 +1,51 @@
+# Why I built a structural diagnostic for my own "agentic" memory systems — and how I actually use it
+
+*A longer note behind [multipass-structural-memory-eval](https://github.com/M0nkeyFl0wer/multipass-structural-memory-eval).*
+
+## The itch
+
+I have recently become obsessed with Knowledge Graphs. I will be the first one to admit that I have become like the wack job connecting different colours of string to pins representing nodes in a graph. But there are reasons behind my madness. The most immediate problem I was trying to solve was maintaining memory over long sessions or across different projects within my own work environment. This is the same problem many many people are trying to solve and truth be told its not a one size fits all solution Its also worth saying, like a relative said to me when i tried to explain why I was spending so much time building graphs "I would love to have more accurate memory too" They were talking about in their own brain, not their "second brain" on a computer but for many of us the division between the first and second is getting blurrier all the time.
+
+So I built myself a personal knowledge-graph RAG stack (everything I've typed, decided or saved, ingested into an embedded graph), plus the usual pile of RAG and agent-memory experiments. The promise of all of it is the same: *the structure gives you something retrieval alone can't* multi-hop chains, contradiction surfacing, "what superseded this," provenance.
+
+The problem is that every benchmark I could find measures the wrong thing. They ask **"can you find a memory?"** — recall ok, answer accuracy. That's necessary, but a filing cabinet can find a memory. None of them answer the question I actually care about: **is the structure of my graph any good, and is my build actually using it?**
+
+I kept getting burned by failures that retrieval metrics literally cannot see:
+
+- A graph that looked fine but had silently **fragmented** into hundreds of disconnected islands — multi-hop was dead, and R@5 never moved.
+- The same entity split under two IDs because two slug functions disagreed on one character — recall capped below the ceiling, both rows looked fine in isolation.
+- Whole enrichment timers dead for days; the eval stayed green the entire time because it measures "can retrieval return good results *when called*," not whether anything is still flowing.
+
+These are *structural* and *operational* failures. A leaderboard score will sit there at 85% while five of them are active.
+
+## What it actually does
+
+So I built the thing I wanted: a **diagnostic**, not a benchmark. It runs multiple passes over a memory system across several corpus shapes and retrieval conditions, and reports on nine categories of structural health — factual lookup, multi-hop, contradiction, alias resolution, *gaps* (the room that should exist and doesn't), ontology coherence, token efficiency, and — the one every deployment actually trips on — whether the model **reaches the memory at all when it runs in production** (Cat 9, "The Handshake").
+
+The honest unit isn't a single score. It's **before/after deltas under identical conditions** and **within-system A/B/C ablations** — change one thing, hold everything else, read the difference. That's what's defensible, and it's what tells me whether a change I made helped or quietly hurt.
+
+## How I actually use it
+
+Not as a leaderboard. As a **standing health check on my own graph.**
+
+It runs on a schedule against my live personal knowledge graph and tells me when the structure regressed — when a rebuild fragmented something, when a category's coverage cratered, when the ontology drifted from what I declared. The loop is simply: *run it, see what got worse, fix the graph, watch the number recover.* It makes my graphs healthier over time instead of just scoring them once. That dogfooding loop is the actual product; the public benchmark stuff is downstream of it.
+
+## A concrete example (the good-dog demo)
+
+To have something shareable that isn't my private graph, I built a small public corpus — ~60 notes on dog breeds, nutrition, behavior, and policy — where every note carries **hand-authored ground-truth edges** in its frontmatter. The answer key ships with the corpus.
+
+Then I rebuilt the graph from scratch with a Claude-subagent extraction pipeline (strong model for edges, local model only for embeddings — small models fabricate a huge fraction of typed edges), and measured the result against that answer key: **86% edge-recall, zero fabricated edges**, and a connected core that grew from 27 nodes to 289 once the extraction was done right.
+
+The most telling result wasn't the score — it's that the diagnostic **caught errors in its own answer key.** A few of the hand-authored ground-truth edges were just wrong (e.g. "AKC is a member of the FCI" — it isn't), and the extractor *correctly declined to assert them*. The diagnostic flagged them as misses; they were the answer key's bugs, not the graph's. That's the kind of thing you only catch when you're watching structure, not scores.
+
+That's the posture I want from a memory tool: not "you scored 0.85," but "here's the room that's missing, here's the edge that's lying, here's where your structure decayed since last week."
+
+## Where it came from — and the name
+
+It didn't start as a solo project: it grew out of a thread on **[MemPalace](https://github.com/MemPalace/mempalace)** ([issue #101](https://github.com/MemPalace/mempalace/issues/101)) about how you'd actually *test* a memory-palace / second-brain system — not just retrieve from it, but check whether its structure holds up.
+
+The name is Leeloo's line from *The Fifth Element* — **"Multipass!"** (much respect to [milla-jovovich](https://github.com/milla-jovovich)) — and it turned out to describe the method: **multiple passes** over every system under test, across several corpus shapes and retrieval conditions (A / B / C), so brittle default behaviours that hide on any single pass become visible when the readings are compared side by side. The structure is the point; the score is just how you read it.
+
+---
+
+*Diagnostic posture, not a leaderboard. Repo + the nine-category menu: https://github.com/M0nkeyFl0wer/multipass-structural-memory-eval*

--- a/docs/gists/why-benchmarks-cant-see-the-bug.md
+++ b/docs/gists/why-benchmarks-cant-see-the-bug.md
@@ -1,0 +1,79 @@
+# Why a graph benchmark can't see the bug that matters
+
+There's a careful, well-built benchmark making the rounds for embedded graph
+engines — [`prrao87/graph-benchmark`](https://github.com/prrao87/graph-benchmark).
+It generates a 100K-person social network with Faker, loads it into Neo4j, Kuzu,
+[Ladybug](https://github.com/LadybugDB/ladybug), and lance-graph, and times a
+suite of nine queries in milliseconds. It's a good piece of work, and the
+question it answers is a real one.
+
+But it answers a *different* question than the one I spend my time on, and the
+difference turns out to be the whole point.
+
+## Two questions, one substrate
+
+A performance benchmark asks: **given a correct graph, how fast does the engine
+answer?**
+
+The diagnostics I build ask: **given an engine, is the graph correct, complete,
+and coherent in the first place?**
+
+Those are orthogonal axes. And the performance genre doesn't just ignore the
+second one — it *defines it away*. The dataset is correct by construction: Faker
+doesn't fabricate edges, drop entities, duplicate them, or let an ontology drift.
+Clean data goes in, speed comes out, correctness is assumed. That assumption is
+exactly the thing worth measuring on a real system.
+
+## The blind spot is structural, not incidental
+
+This isn't a knock on any particular benchmark or engine. It's a property of the
+*genre*. A real knowledge graph is almost never populated by a clean generator —
+it's built by an extraction pipeline chewing on messy input. That pipeline is
+where the failures that actually hurt you live:
+
+- **Fabricated edges** — an LLM extractor inventing a relationship that isn't in
+  the source.
+- **Fragmented or duplicated entities** — one real-world thing landing as several
+  nodes, or several things collapsed into one.
+- **Ontology drift** — entity and edge types quietly diverging from the schema
+  over successive ingests.
+
+None of these are properties of the *database*. They're properties of the
+*pipeline that fills it*. A benchmark that bulk-loads ground-truth-clean data and
+runs read-only queries cannot see any of them — there's nothing dirty to catch.
+So the genre is complementary to correctness testing, not a substitute for it.
+
+## How you actually test for it
+
+If clean-data-in / speed-out can't surface these, what does? You measure the
+graph itself, structurally:
+
+- **Ingestion integrity** — do edges trace back to real source spans, or were
+  they invented? Do entities that should be one node collide, or stay
+  fragmented?
+- **Ontology coherence** — do the types and relationships in the graph still
+  match the schema they were supposed to follow, ingest after ingest?
+- **Topology** — degree distribution, connected components, communities, holes.
+  Is the graph one connected fabric or a pile of disconnected islands?
+
+That last one is also where the two worlds quietly meet. A performance
+benchmark's results are *driven* by topology: the queries that discriminate one
+engine from another are the multi-hop path queries, and those explode precisely
+when the generator plants super-nodes and dense cliques. Hub density is what
+makes a path query expensive. So the structural signature of a graph doesn't just
+tell you whether it's *correct* — it predicts where it'll be *slow*. Speed and
+correctness turn out to sit on the same substrate: the shape of the graph.
+
+## Credit where it's due
+
+The benchmark that prompted this is genuinely good, and the Ladybug maintainer's
+response to it — engaging with a third-party result that beat them, crediting
+upstream work openly, and shipping concrete fixes within weeks — is exactly the
+kind of engaged, research-honest maintenance you want under a database you depend
+on. None of the above is a criticism of that work. It's a note about what the
+*category* of test can and can't see, and why the correctness question needs its
+own instruments.
+
+Speed benchmarks tell you whether a correct graph is fast. They can't tell you
+whether your graph is correct. Both questions matter; they just need different
+tools.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -499,6 +499,21 @@ about a retriever in isolation.
 
 ---
 
+### Topology as a workload-cost predictor (research thread, 2026-06-20)
+
+Performance benchmarks (e.g. `prrao87/graph-benchmark`) have result tables
+driven entirely by graph *structure*: planted super-nodes and cliques are why
+the n-hop path queries explode and discriminate engines. That hub
+density / degree distribution / fanout is exactly what SME's Cat 5 instruments
+measure. A latency benchmark *observes* the explosion; SME's topology layer could
+*predict* it from the structural signature. **Unclaimed, paper-shaped:**
+structural / persistent-homology signature as a predictor of query workload cost.
+Not a test — an experiment. See `docs/related_work/graph-benchmark.md`. Pairs
+with the defect-injecting corpus generator (the other reusable move from that
+benchmark family).
+
+---
+
 ## Prior art
 
 SME builds on and cites work from:

--- a/docs/industry_benchmark_gap_analysis_2026.md
+++ b/docs/industry_benchmark_gap_analysis_2026.md
@@ -66,6 +66,47 @@ Similarly, SME's conversational-memory coverage is **longitudinally thin** — w
 
 **Verdict:** SME has one strong domain-specific integration (CKG) but no others. The framework is designed to be adapter-agnostic — adding new domain-specific benchmark adapters is the intended extension pattern. No structural changes needed; the gap is corpus coverage.
 
+### 2.5 Performance / Latency Benchmarks
+
+> Added 2026-06-20. Full note: `docs/related_work/graph-benchmark.md`.
+
+| Benchmark | SME Equivalent | Status | Notes |
+|---|---|---|---|
+| **prrao87/graph-benchmark** (engine latency on a synthetic graph) | *None — and intentionally so* | **Orthogonal** | Pure latency benchmark: Faker generates a fixed-schema 100K-person graph (correct by construction), a 9-query suite is timed in ms across four engines (Neo4j 2025.12.1, Kuzu 0.11.3, **Ladybug 0.15.3**, lance-graph 0.5.4 — 0.15.3 is *not* current; PyPI is at 0.17.1). Correctness is an *assumption*, not a variable. Numbers verified against the live README 2026-06-20; we also re-ran 0.15.3 vs 0.17.1 on one machine (see `docs/related_work/graph-benchmark.md`) — **latency unchanged, on-disk size ~10% smaller on 0.17.1**. |
+| **LadybugDB "ball" optimization post** (space/latency tuning) | N/A | **Reference** | Vendor-self-reported storage tuning (hash-index-off, forward-only rels). Informs production-graph footprint, not the test surface. |
+
+**Verdict:** This is a **fifth benchmark family** the rest of this doc does not
+cover, and the relationship to SME is **orthogonal**, not a gap to close. A
+performance benchmark asks "given a *correct* graph, how fast does the engine
+answer?"; SME asks "given an engine, is the graph correct/complete/coherent?"
+The performance genre defines away precisely what SME measures, because its
+harness shape — bulk-load ground-truth-clean data, run read-only timed queries —
+is *structurally blind* to **construction-quality** failures: fabricated edges,
+fragmented/duplicate entities, ontology drift. These are properties of the
+*pipeline that populates the graph*, not of the engine, so the framing is
+complementary, not a criticism of any DB.
+
+Two things to *take* from it rather than cover:
+
+1. **Method to borrow (separate feature):** the generative dataset with known
+   ground truth (`generate_data.sh N`). A defect-injecting corpus generator
+   (`generate_corpus.sh N --fabrication-rate ...`) would let Cat 4/5/8 be scored
+   as detection precision/recall against planted defects — turning SME from a
+   test suite into a scored benchmark. Tracked as future work, not in this
+   doc's roadmap.
+2. **Bridge to write up (research thread, parked in `ideas.md`):** the
+   benchmark's result table is driven by graph *topology* (planted super-nodes /
+   cliques cause the path-query explosions that discriminate engines), which is
+   exactly what SME's Cat 5 instruments measure. "Structural signature as a
+   workload-cost predictor" is unclaimed, paper-shaped ground.
+
+**Do not** instantiate the blind-spot with any storage-corruption claim. The
+earlier LadybugDB incremental-write corruption story is unconfirmed on the latest
+build (a standalone per-edge repro on 0.17.1 found zero corruption; the earlier
+observation is best explained as a mis-measured dedup-merge effect). It must not
+appear in any founder-facing or public writeup. The construction-quality framing
+above is stronger and does not need it.
+
 ---
 
 ## 3. Where SME Reinvents the Wheel (And Whether That's OK)

--- a/docs/related_work/graph-benchmark.md
+++ b/docs/related_work/graph-benchmark.md
@@ -1,0 +1,201 @@
+# Graph Performance Benchmarks — Related Work
+
+> **Date:** 2026-06-20
+> **Scope:** `prrao87/graph-benchmark` and the LadybugDB "better graph database
+> ball" optimization post, mapped against SME's structural diagnostics.
+> **Purpose:** Locate the performance/latency-benchmark genre relative to SME,
+> establish that they measure orthogonal axes, and identify the one method worth
+> borrowing (generative dataset with known ground truth) and the one bridge worth
+> writing up (topology as a workload-cost predictor).
+
+This is the fifth benchmark family relative to the four in
+`docs/industry_benchmark_gap_analysis_2026.md` (RAG Triad/TRACe, conversational
+memory, NIAH, domain-specific reasoning). That doc does not cover performance
+benchmarking at all; this note is the additive section, summarized there as §2.5.
+
+## What prrao87/graph-benchmark is
+
+A pure latency benchmark on a **synthetic** graph. Faker generates a 100K-person
+social-network graph with a fixed schema (`Person FOLLOWS Person`, `LIVES_IN`,
+`HAS_INTEREST`, `CITY_IN`, `STATE_IN`), then a 9-query suite is timed in
+milliseconds across **four separately-versioned engines**. The dataset is
+**correct by construction** — Faker does not fabricate edges, drop entities,
+duplicate entities, or drift an ontology. Correctness is therefore not a variable
+in the benchmark; it is an assumption.
+
+> **Verified against the current README on 2026-06-20** (raw fetch of
+> `prrao87/graph-benchmark@main`):
+> - Dataset: 100,000 persons; 2,417,738 `FOLLOWS` edges (~2.4M); **500 planted
+>   super-nodes**; 9 queries (q1–q9).
+> - Engines and pinned versions: **Neo4j 2025.12.1, Kuzu 0.11.3, Ladybug 0.15.3,
+>   lance-graph 0.5.4**.
+> - q8 ("how many second-degree paths exist?"): Neo4j **2831.2 ms** vs Ladybug
+>   **7.3 ms** (385.8×); Kuzu 6.5 ms (435.3×); lance-graph 126.2 ms.
+> - The README itself notes RNG variance across runs, so trends — not exact
+>   milliseconds — are the durable claim.
+>
+> **Version caveat (load-bearing for the founder).** The published numbers are
+> for **ladybug-0.15.3**, which is **not** the latest release — PyPI `ladybug`
+> is at **0.17.1** as of 2026-06-20, post-dating the storage work in the "ball"
+> post below. Do not present these figures as reflecting current Ladybug
+> performance; cite them as "0.15.3, as published." We re-ran both 0.15.3 and
+> 0.17.1 ourselves on one machine to get a current, apples-to-apples delta — see
+> the next section.
+
+## Re-run on ladybug 0.17.1 — measured 2026-06-20
+
+The published table is locked to ladybug-0.15.3, so to give current numbers we
+re-ran the benchmark ourselves on **0.17.1** (latest) and, for a fair delta, on
+**0.15.3** on the *same machine*. Both from PyPI wheels.
+
+**Method (identical for both versions):** cloned `prrao87/graph-benchmark@main`,
+regenerated the dataset with `generate_data.sh 100000` (RNG-regenerated, same
+shape: 100K persons / 2,417,738 follows edges / 500 super-nodes), ingested via the
+repo's own `build_graph.py`, ran the repo's own `benchmark_query.py` with the
+documented invocation (`pytest-benchmark`, `--benchmark-min-rounds=5
+--benchmark-warmup-iterations=5 --benchmark-disable-gc`). Environment:
+monkey-flower desktop, 12 cores, load ~1.5–2.0, Python 3.13. Two runs per version.
+The benchmark scripts ran **unmodified** on 0.17.1 (the only API drift —
+`QueryResult.to_dicts()` → `.get_as_pl()` — is already absorbed inside `query.py`).
+
+**Median latency (ms), this machine, two runs each:**
+
+| Query | 0.15.3 (A / B) | 0.17.1 (A / B) | *published 0.15.3 (prrao87 box)* |
+| --- | --- | --- | --- |
+| q1 | 486.8 / 494.2 | 529.0 / 486.9 | *152.0* |
+| q2 | 762.9 / 746.8 | 775.4 / 766.5 | *236.8* |
+| q3 | 43.5 / 36.5 | 33.4 / 33.8 | *6.7* |
+| q4 | 50.6 / 39.0 | 50.4 / 67.5 | *10.2* |
+| q5 | 60.9 / 61.9 | 56.2 / 61.2 | *11.5* |
+| q6 | 124.5 / 112.4 | 131.7 / 123.6 | *30.0* |
+| q7 | 69.8 / 61.1 | 64.9 / 60.6 | *12.1* |
+| q8 | 28.7 / 25.2 | 27.9 / 26.4 | *7.1* |
+| q9 | 163.6 / 161.2 | 166.0 / 165.9 | *94.3* |
+
+On-disk DB size: **0.15.3 = 50 MB, 0.17.1 = 45 MB (~10% smaller).**
+
+**Findings (honest, founder-facing):**
+
+1. **Latency: 0.17.1 ≈ 0.15.3 — no regression, no notable gain on this read-only
+   suite.** The version-to-version differences are *smaller than each version's
+   own run-to-run variance* (e.g. 0.17.1 q4 swings 50.4→67.5 ms between its own
+   two runs), so the deltas are noise, not signal.
+2. **On-disk footprint shrank ~10% (50→45 MB) on 0.17.1** — a real, repeatable
+   improvement, consistent with the storage work described in the "ball" post.
+3. **Absolute ms are not comparable to the published table.** This desktop is
+   ~3–4× slower than prrao87's box on the *same* version (published 0.15.3 q8
+   = 7.1 ms vs our 0.15.3 q8 ≈ 27 ms), so read the published numbers as *their*
+   hardware and our numbers only against *each other*. Hardware/load dominates
+   absolute timings; only the same-box version delta is valid here.
+4. **Query shape is preserved across versions:** the follower-aggregation queries
+   (q1/q2) are the heavy ones; the second-degree path-count (q8) stays cheap —
+   the factorization/WCOJ advantage holds in both 0.15.3 and 0.17.1.
+5. **Scope of this re-run:** read-query latency + load-once ingest only. It does
+   **not** exercise the space-amplification tuning knobs from the "ball" post
+   (hash-index-off / forward-only rels — those need config changes and on-disk
+   measurement), and it does **not** reproduce the cross-engine gap (we ran
+   ladybug only — no Neo4j/lance-graph on this box).
+
+> Scratch tree for this run: `/tmp/graph-benchmark-rerun` (not committed). Anyone
+> can reproduce with the method above; numbers will shift with hardware/load but
+> the 0.15.3≈0.17.1 conclusion should hold.
+
+## The core relationship: orthogonal axes
+
+- A performance benchmark asks: **"given a correct graph, how fast does the
+  engine answer?"**
+- SME asks: **"given an engine, is the graph correct, complete, and coherent?"**
+
+The performance genre *defines away* precisely the thing SME measures. Clean data
+in, speed measured, correctness assumed. That is SME's differentiation expressed
+against a careful, real artifact rather than as a slogan.
+
+### Why the genre is structurally blind to construction quality
+
+This is the founder-safe framing, and it is also the stronger one. Because the
+generator emits **ground-truth-clean** data, a performance benchmark cannot
+observe any failure that lives in how a *real* graph gets built from messy input:
+
+- **fabricated edges** — an LLM extraction pipeline inventing relationships that
+  aren't in the source;
+- **fragmented / duplicate entities** — the same real-world thing landing as
+  several nodes (or several things collapsed into one);
+- **ontology drift** — entity/edge types diverging from the schema over
+  successive ingests.
+
+None of these are properties of the *engine* — they are properties of the
+*pipeline that populates it*. That is exactly the axis SME measures (Cat 4
+ingestion integrity, Cat 8 ontology coherence), and it is genuinely complementary
+to a latency benchmark rather than a criticism of one. Clean data in, speed
+measured; SME asks whether the data was clean in the first place.
+
+A secondary, neutral observation: the load-once-then-read harness shape also
+doesn't exercise incremental-write/checkpoint paths. State this only as "not
+exercised," nothing more.
+
+> **Do not assert storage corruption.** An earlier internal note framed the
+> blind spot around a specific LadybugDB incremental-write corruption. As of
+> 2026-06-20 that claim is **unconfirmed on the latest build**: a minimal
+> standalone repro on **0.17.1** (pristine DB, single process, per-edge
+> intended-state tracking, 30 trials across 6 mechanisms) found **zero
+> corruption**; the original observation is best explained as a mis-measured
+> dedup-merge effect (a raw before/after aggregate delta crediting none of the
+> merge's intended changes). This claim must not appear in any founder-facing or
+> public writeup. It is omitted from the construction-quality framing above
+> deliberately, and that framing does not need it.
+
+## What's worth borrowing: generative dataset with known ground truth
+
+The reusable methodological move is `generate_data.sh N` — a scalable synthetic
+generator whose ground truth is known by construction. SME's corpus today is
+fixed and hand-built, which makes SME a *test suite*. A defect-injecting
+generator —
+
+```
+generate_corpus.sh N --fabrication-rate 0.45 --missing-rate 0.1 --dup-rate ...
+```
+
+— synthesizes a graph with planted fabrications, missing entities, duplicate
+entities, and ontology violations at controllable rates. Then Cat 4/5/8 can be
+scored as **detection precision/recall against defects you injected**, at scale.
+That is the move that turns SME from runnable into citable. (Scoped separately as
+a feature; this note only records the rationale.)
+
+## The bridge worth writing up: topology as a workload-cost predictor
+
+The two genres meet at **topology**, not methodology. The benchmark's entire
+result table is driven by graph structure: the discriminating path queries
+explode specifically because the generator plants super-nodes and cliques —
+hub density causes path-count explosions. The variable that determines the
+performance curve *is* the degree distribution / hub presence / clique density /
+fanout — exactly what SME's Cat 5 instruments measure (centrality, Louvain
+communities, degree distribution, connectivity).
+
+So a latency benchmark *observes* that a path query explodes; SME's topology
+layer can *explain and predict* it from the graph's structural signature. The
+unclaimed ground: **structural / persistent-homology signature as a workload-cost
+predictor.** That is paper-shaped and is parked in `docs/ideas.md`, not a test.
+
+Operationally it also pays off for free: a sparse, fragmented graph (low LCC,
+low mean degree, mostly isolated entities) lacks the hub density to explode on
+the path queries that discriminate this benchmark — so SME's existing
+connectivity instruments already predict the performance profile without running
+a latency benchmark at all.
+
+## Context: the LadybugDB "ball" optimization post
+
+`blog.ladybugdb.com/post/better-graph-database-ball/` — vendor-self-reported, so
+discount the framing, but the substance is useful:
+
+- **Space amplification:** default config ~2× DuckDB on this workload; disabling
+  the default hash-index-as-PK and switching to forward-only rel storage closes
+  most of the gap. Relevant to the production graph's footprint *only after*
+  auditing whether backward traversals ("who points at this entity") are actually
+  used — for a KG they often are, so do not drop them blind.
+- **Health signal:** maintainer responded to a third-party benchmark that beat
+  them within weeks, credited DuckDB openly, and shipped concrete PRs. Engaged,
+  research-honest maintainer — a positive datapoint for depending on the engine.
+- **Honest performance read:** even post-optimization, DuckDB remains multiples
+  faster on every query. Not SME's bottleneck — SME's traversal/topology runs
+  offline in NetworkX/Ripser and uses the engine as edge storage + projection
+  source, not as a hot serving path.


### PR DESCRIPTION
Founder-bound explainer docs (all under `docs/`), cherry-picked off `origin/main` so they don't carry the stale CKG feature branch.

## What's here
- `docs/gists/why-and-how.md` — canonical, dogfooding-led why/how explainer (the first gist to ship).
- `docs/gists/why-benchmarks-cant-see-the-bug.md` — companion: perf benchmarks measure speed on correct-by-construction data; SME measures whether the graph is *correct*.
- `docs/gists/origin-how-multipass-began.md` — long-form origin (MemPalace #101). Note: partially redundant with the inline origin in `why-and-how.md` — candidate to prune later.
- `docs/related_work/graph-benchmark.md` — prrao87 relation + same-machine 0.15.3-vs-0.17.1 re-run (latency flat within noise; on-disk ~10% smaller on 0.17.1, 50→45MB). Numbers verified vs live README.
- `docs/industry_benchmark_gap_analysis_2026.md` §2.5 (perf = fifth family) + `docs/ideas.md` (topology-as-cost-predictor thread).

## Founder-safety
These are intended to be shared with the LadybugDB founder. The earlier "incremental-write corruption" claim is **debunked on 0.17.1** (standalone per-edge repro, 0 corruption; mis-measured dedup-merge effect) and appears here only as explicit *do-not-assert* guard-rail framing. No AI-attribution lines.